### PR TITLE
Relax constraint on containers to allow 0.5.7 or greater.

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -63,7 +63,7 @@ executable matterhorn
                      , mattermost-api >= 30701.1.0
                      , base-compat
                      , unordered-containers
-                     , containers >= 0.5.8
+                     , containers >= 0.5.7
                      , connection
                      , text
                      , bytestring

--- a/src/Draw/Main.hs
+++ b/src/Draw/Main.hs
@@ -328,9 +328,9 @@ renderCurrentChannelDisplay uSet cSet st = (header <+> conn) <=> messages
         case Seq.findIndexR (\m -> m^.mPostId == Just selPostId) msgs of
             Nothing -> renderLastMessages msgs
             Just idx ->
-                case Seq.lookup idx msgs of
-                    Nothing -> renderLastMessages msgs
-                    Just curMsg -> unsafeMessageSelectList msgs idx curMsg
+                if idx < (Seq.length msgs) && idx >= 0
+                then unsafeMessageSelectList msgs idx $ msgs `Seq.index` idx
+                else renderLastMessages msgs
 
     unsafeMessageSelectList msgs idx curMsg = Widget Greedy Greedy $ do
         ctx <- getContext

--- a/src/State.hs
+++ b/src/State.hs
@@ -143,7 +143,9 @@ getSelectedMessage st
         let chanMsgs = st ^. csCurrentChannel . ccContents . cdMessages
 
         idx <- Seq.findIndexR (\m -> m^.mPostId == Just selPostId) chanMsgs
-        Seq.lookup idx chanMsgs
+        if idx < (Seq.length chanMsgs) && idx >= 0
+        then Just $ chanMsgs `Seq.index` idx
+        else Nothing
 
 messageSelectUp :: MH ()
 messageSelectUp = do


### PR DESCRIPTION
A couple of small tweaks lose a little laziness in the implementation but adds support for the older containers library.  This is useful because containers is closely related to ghc versioning and is a basis for a large number of other libraries, so if the native environment doesn't yet support the containers 0.5.8 (released Aug 31, 2016) it is likely to have containers 0.5.7 (released Dec 17, 2015).