### PR TITLE
List CHANGELOG.md in extra-doc-files

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -14,7 +14,7 @@ build-type:          Simple
 cabal-version:       >= 1.18
 tested-with:         GHC == 7.10.3, GHC == 8.0.1
 
-extra-doc-files:     README.md
+extra-doc-files:     CHANGELOG.md, README.md
 
 source-repository    head
   type: git


### PR DESCRIPTION
This way, the changelog will be linked to from Hackage, which is handy.