### PR TITLE
Add a command to search posts

### DIFF
--- a/src/Command.hs
+++ b/src/Command.hs
@@ -103,6 +103,9 @@ commandList =
 
   , Cmd "flags" "Open up a pane of flagged posts"  NoArg $ \ () ->
       enterFlaggedPostListMode
+
+  , Cmd "search" "Search for posts with given terms"  (LineArg "terms") $
+      enterSearchResultPostListMode
   ]
 
 execMMCommand :: T.Text -> T.Text -> MH ()

--- a/src/Draw/PostListOverlay.hs
+++ b/src/Draw/PostListOverlay.hs
@@ -69,8 +69,11 @@ drawPostsBox contents st =
     padRight (Pad 1) messageListContents
   where -- The 'window title' of the overlay
         contentHeader = withAttr channelListHeaderAttr $ txt $ case contents of
-          PostListFlagged        -> "Flagged posts"
-          PostListSearch terms _ -> "Search results: " <> terms
+          PostListFlagged                -> "Flagged posts"
+          PostListSearch terms searching -> "Search results" <> if searching
+            then ": " <> terms
+            else " (" <> (T.pack . show . length) (st^.csPostListOverlay.postListPosts) <> "): " <> terms
+
         -- User and channel set, for use in message rendering
         uSet = Set.fromList (st^..csUsers.to allUsers.folded.uiName)
         cSet = Set.fromList (st^..csChannels.folded.ccInfo.cdName)

--- a/src/Draw/PostListOverlay.hs
+++ b/src/Draw/PostListOverlay.hs
@@ -69,7 +69,8 @@ drawPostsBox contents st =
     padRight (Pad 1) messageListContents
   where -- The 'window title' of the overlay
         contentHeader = withAttr channelListHeaderAttr $ txt $ case contents of
-          PostListFlagged -> "Flagged posts"
+          PostListFlagged        -> "Flagged posts"
+          PostListSearch terms _ -> "Search results: " <> terms
         -- User and channel set, for use in message rendering
         uSet = Set.fromList (st^..csUsers.to allUsers.folded.uiName)
         cSet = Set.fromList (st^..csChannels.folded.ccInfo.cdName)
@@ -87,7 +88,11 @@ drawPostsBox contents st =
             hCenter $
             withDefAttr clientEmphAttr $
             str $ case contents of
-              PostListFlagged -> "You have no flagged messages."
+              PostListFlagged            -> "You have no flagged messages."
+              PostListSearch _ searching ->
+                if searching
+                  then "Searching ..."
+                  else "No search results found"
           | otherwise = vBox renderedMessageList
 
         -- The render-message function we're using

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -435,8 +435,8 @@ data HelpTopic =
 -- | Mode type for the current contents of the post list overlay
 data PostListContents
   = PostListFlagged
---   | PostListPinned ChannelId
---   | PostListSearch Text -- for the query
+  | PostListSearch T.Text Bool -- for the query and search status
+  --   | PostListPinned ChannelId
   deriving (Eq)
 
 -- | The 'Mode' represents the current dominant UI activity


### PR DESCRIPTION
Adds a new command `/search [terms]` to search posts. The search results are shown in the post list overlay. This uses the `mmSearchPosts` function from the API package for which a PR is [open](https://github.com/matterhorn-chat/mattermost-api/pull/39/files). 
This fixes issue #328.