### PR TITLE
Show an indicator for users who are currently typing

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -88,6 +88,7 @@ executable matterhorn
                      , base-compat          >= 0.9    && < 0.10
                      , unordered-containers >= 0.2    && < 0.3
                      , containers           >= 0.5.7  && < 0.6
+                     , semigroups           >= 0.18   && < 0.19
                      , connection           >= 0.2    && < 0.3
                      , text                 >= 1.2    && < 1.3
                      , bytestring           >= 0.10   && < 0.11

--- a/sample-config.ini
+++ b/sample-config.ini
@@ -161,7 +161,8 @@
 #
 # showOlderEdits = True
 
-# Whether to show the indicator for users typing.
+# Whether to show the indicator for users typing and to send the typing
+# notifications to the server.
 # Default: False
 #
 # showTypingIndicator = False

--- a/sample-config.ini
+++ b/sample-config.ini
@@ -160,3 +160,8 @@
 # Default: True
 #
 # showOlderEdits = True
+
+# Whether to show the indicator for users typing.
+# Default: False
+#
+# showTypingIndicator = False

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -51,6 +51,8 @@ fromIni = do
       (configShowBackground defaultConfig)
     configShowMessagePreview <- fieldFlagDef "showMessagePreview"
       (configShowMessagePreview defaultConfig)
+    configShowTypingIndicator <- fieldFlagDef "showTypingIndicator"
+      (configShowTypingIndicator defaultConfig)
     configEnableAspell <- fieldFlagDef "enableAspell"
       (configEnableAspell defaultConfig)
     configActivityBell <- fieldFlagDef "activityBell"
@@ -95,27 +97,28 @@ isQuoted t =
 
 defaultConfig :: Config
 defaultConfig =
-    Config { configAbsPath            = Nothing
-           , configUser               = Nothing
-           , configHost               = Nothing
-           , configTeam               = Nothing
-           , configPort               = defaultPort
-           , configPass               = Nothing
-           , configTimeFormat         = Nothing
-           , configDateFormat         = Nothing
-           , configTheme              = Nothing
-           , configThemeCustomizationFile = Nothing
-           , configSmartBacktick      = True
-           , configURLOpenCommand     = Nothing
+    Config { configAbsPath                   = Nothing
+           , configUser                      = Nothing
+           , configHost                      = Nothing
+           , configTeam                      = Nothing
+           , configPort                      = defaultPort
+           , configPass                      = Nothing
+           , configTimeFormat                = Nothing
+           , configDateFormat                = Nothing
+           , configTheme                     = Nothing
+           , configThemeCustomizationFile    = Nothing
+           , configSmartBacktick             = True
+           , configURLOpenCommand            = Nothing
            , configURLOpenCommandInteractive = False
-           , configActivityBell       = False
-           , configShowBackground     = Disabled
-           , configShowMessagePreview = False
-           , configEnableAspell       = False
-           , configAspellDictionary   = Nothing
-           , configUnsafeUseHTTP    = False
-           , configChannelListWidth = 20
-           , configShowOlderEdits     = True
+           , configActivityBell              = False
+           , configShowBackground            = Disabled
+           , configShowMessagePreview        = False
+           , configEnableAspell              = False
+           , configAspellDictionary          = Nothing
+           , configUnsafeUseHTTP             = False
+           , configChannelListWidth          = 20
+           , configShowOlderEdits            = True
+           , configShowTypingIndicator       = False
            }
 
 findConfig :: Maybe FilePath -> IO (Either String Config)

--- a/src/Connection.hs
+++ b/src/Connection.hs
@@ -34,6 +34,12 @@ connectWebsockets = do
     void $ forkIO $ runWS `catch` handleTimeout 1 st
                           `catch` handleError 5 st
 
+-- | Take websocket actions from the websocket action channel in the ChatState and
+-- | send them to the server over the websocket.
+-- | Takes and propagates the action sequence number which in incremented for
+-- | each successful send.
+-- | Keeps and propagates a map of channel id to last user_typing notification send time
+-- | so that the new user_typing actions are throttled to be send only once in two seconds.
 processWebsocketActions :: ChatState -> WS.MMWebSocket -> Int64 -> HM.HashMap ChannelId (Max UTCTime) -> IO ()
 processWebsocketActions st ws s userTypingLastNotifTimeMap = do
   action <- STM.atomically $ STM.readTChan (st^.csWebsocketActionChan)

--- a/src/Connection.hs
+++ b/src/Connection.hs
@@ -10,10 +10,13 @@ import           Control.Exception (SomeException, catch)
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.Int (Int64)
+import qualified Data.HashMap.Strict as HM
+import           Data.Semigroup (Max(..), (<>))
 import           Data.Time (UTCTime(..), secondsToDiffTime, getCurrentTime, diffUTCTime)
 import           Data.Time.Calendar (Day(..))
 import           Lens.Micro.Platform
 
+import           Network.Mattermost.Types (ChannelId)
 import qualified Network.Mattermost.WebSocket as WS
 
 import           Constants
@@ -27,26 +30,32 @@ connectWebsockets = do
         shunt (Right e) = writeBChan (st^.csResources.crEventQueue) (WSEvent e)
         runWS = WS.mmWithWebSocket (st^.csResources.crSession) shunt $ \ws -> do
                   writeBChan (st^.csResources.crEventQueue) WebsocketConnect
-                  processWebsocketActions st ws 1 zeroTime
+                  processWebsocketActions st ws 1 HM.empty
     void $ forkIO $ runWS `catch` handleTimeout 1 st
                           `catch` handleError 5 st
-  where
-    zeroTime = UTCTime (ModifiedJulianDay 0) (secondsToDiffTime 0)
 
-processWebsocketActions :: ChatState -> WS.MMWebSocket -> Int64 -> UTCTime -> IO ()
-processWebsocketActions st ws s lastUserTypingNotifTime = do
+processWebsocketActions :: ChatState -> WS.MMWebSocket -> Int64 -> HM.HashMap ChannelId (Max UTCTime) -> IO ()
+processWebsocketActions st ws s userTypingLastNotifTimeMap = do
   action <- STM.atomically $ STM.readTChan (st^.csWebsocketActionChan)
   if (shouldSendAction action)
     then do
       WS.mmSendWSAction (st^.csResources.crConn) ws $ convert action
-      processWebsocketActions st ws (s + 1) =<< getCurrentTime
+      now <- getCurrentTime
+      processWebsocketActions st ws (s + 1) $ userTypingLastNotifTimeMap' action now
     else do
-      processWebsocketActions st ws s lastUserTypingNotifTime
+      processWebsocketActions st ws s userTypingLastNotifTimeMap
   where
     convert (UserTyping _ cId pId) = WS.UserTyping s cId pId
 
-    shouldSendAction (UserTyping ts _ _) =
-      diffUTCTime ts lastUserTypingNotifTime >= (userTypingExpiryInterval / 2 - 0.5)
+    shouldSendAction (UserTyping ts cId _) =
+      diffUTCTime ts (userTypingLastNotifTime cId) >= (userTypingExpiryInterval / 2 - 0.5)
+
+    userTypingLastNotifTime cId = getMax $ HM.lookupDefault (Max zeroTime) cId userTypingLastNotifTimeMap
+
+    zeroTime = UTCTime (ModifiedJulianDay 0) (secondsToDiffTime 0)
+
+    userTypingLastNotifTimeMap' (UserTyping _ cId _) now =
+      HM.insertWith (<>) cId (Max now) userTypingLastNotifTimeMap
 
 handleTimeout :: Int -> ChatState -> WS.MMWebSocketTimeoutException -> IO ()
 handleTimeout seconds st _ = reconnectAfter seconds st

--- a/src/Constants.hs
+++ b/src/Constants.hs
@@ -1,8 +1,15 @@
 module Constants
   ( pageAmount
+  , userTypingExpiryInterval
   )
 where
+
+import Data.Time (NominalDiffTime)
 
 -- | The number of rows to consider a "page" when scrolling
 pageAmount :: Int
 pageAmount = 15
+
+-- | The expiry interval in seconds for user typing notifications.
+userTypingExpiryInterval :: NominalDiffTime
+userTypingExpiryInterval = 5

--- a/src/Draw/Main.hs
+++ b/src/Draw/Main.hs
@@ -319,8 +319,8 @@ renderCurrentChannelDisplay :: ChatState -> HighlightSet -> Widget Name
 renderCurrentChannelDisplay st hs = (header <+> conn) <=> messages
     where
     conn = case st^.csConnectionStatus of
-      Connected -> emptyWidget
-      Disconnected -> withDefAttr errorMessageAttr (str "[NOT CONNECTED]")
+      Connected _ _ -> emptyWidget
+      Disconnected  -> withDefAttr errorMessageAttr (str "[NOT CONNECTED]")
     header = withDefAttr channelHeaderAttr $
              padRight Max $
              renderChannelHeader st hs chan

--- a/src/Draw/Main.hs
+++ b/src/Draw/Main.hs
@@ -46,7 +46,7 @@ import           Types.Channels ( NewMessageIndicator(..)
                                 , ChannelState(..)
                                 , ClientChannel
                                 , ccInfo, ccContents
-                                , cdCurrentState
+                                , cdCurrentState, cdTypingUsers
                                 , cdName, cdType, cdHeader, cdMessages
                                 , findChannelById)
 import           Types.Messages
@@ -586,11 +586,22 @@ mainInterface st =
                  [ hLimit channelListWidth hBorder
                  , borderElem bsIntersectB
                  , hBorder
-                 , showBusy]
+                 , showTypingUsers
+                 , showBusy
+                 ]
+
+    showTypingUsers = case allTypingUsers (st^.csCurrentChannel.ccInfo.cdTypingUsers) of
+                        [] -> emptyWidget
+                        [uId] | Just un <- getUsernameForUserId st uId ->
+                           txt $ un <> " is typing"
+                        [uId1, uId2] | Just un1 <- getUsernameForUserId st uId1
+                                     , Just un2 <- getUsernameForUserId st uId2 ->
+                           txt $ un1 <> " and " <> un2 <> " are typing"
+                        _ -> txt "several people are typing"
 
     showBusy = case st^.csWorkerIsBusy of
-                 Just (Just n) -> txt (T.pack $ "*" <> show n)
-                 Just Nothing -> txt "*"
+                 Just (Just n) -> hLimit 2 hBorder <+> txt (T.pack $ "*" <> show n)
+                 Just Nothing -> hLimit 2 hBorder <+> txt "*"
                  Nothing -> emptyWidget
 
     maybeSubdue = if st^.csMode == ChannelSelect

--- a/src/Draw/Main.hs
+++ b/src/Draw/Main.hs
@@ -319,7 +319,7 @@ renderCurrentChannelDisplay :: ChatState -> HighlightSet -> Widget Name
 renderCurrentChannelDisplay st hs = (header <+> conn) <=> messages
     where
     conn = case st^.csConnectionStatus of
-      Connected _ _ -> emptyWidget
+      Connected -> emptyWidget
       Disconnected  -> withDefAttr errorMessageAttr (str "[NOT CONNECTED]")
     header = withDefAttr channelHeaderAttr $
              padRight Max $

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -46,8 +46,8 @@ onAppEvent :: MHEvent -> MH ()
 onAppEvent RefreshWebsocketEvent = connectWebsockets
 onAppEvent WebsocketDisconnect =
   csConnectionStatus .= Disconnected
-onAppEvent (WebsocketConnect ws) = do
-  csConnectionStatus .= Connected 1 ws
+onAppEvent WebsocketConnect = do
+  csConnectionStatus .= Connected
   refreshChannelsAndUsers
 onAppEvent BGIdle     = csWorkerIsBusy .= Nothing
 onAppEvent (BGBusy n) = csWorkerIsBusy .= Just n

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -139,6 +139,11 @@ handleWSEvent we = do
                     removeChannelFromState cId
             | otherwise -> return ()
 
+        WMTyping
+            | Just uId <- wepUserId $ weData we
+            , Just cId <- webChannelId (weBroadcast we) -> handleTypingUser uId cId
+            | otherwise -> return ()
+
         WMChannelDeleted
             | Just cId <- wepChannelId (weData we) ->
                 when (webTeamId (weBroadcast we) == Just myTeamId) $
@@ -206,7 +211,6 @@ handleWSEvent we = do
         WMChannelCreated -> return ()
         WMEmojiAdded -> return ()
         WMWebRTC -> return ()
-        WMTyping -> return ()
         WMHello -> return ()
         WMAuthenticationChallenge -> return ()
         WMUserRoleUpdated -> return ()

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -43,13 +43,11 @@ onEvent st ev = runMHEvent st $ case ev of
   _ -> return ()
 
 onAppEvent :: MHEvent -> MH ()
-onAppEvent RefreshWebsocketEvent = do
-  st <- use id
-  liftIO $ connectWebsockets st
+onAppEvent RefreshWebsocketEvent = connectWebsockets
 onAppEvent WebsocketDisconnect =
   csConnectionStatus .= Disconnected
-onAppEvent WebsocketConnect = do
-  csConnectionStatus .= Connected
+onAppEvent (WebsocketConnect ws) = do
+  csConnectionStatus .= Connected 1 ws
   refreshChannelsAndUsers
 onAppEvent BGIdle     = csWorkerIsBusy .= Nothing
 onAppEvent (BGBusy n) = csWorkerIsBusy .= Just n

--- a/src/LastRunState.hs
+++ b/src/LastRunState.hs
@@ -26,7 +26,6 @@ import qualified System.Posix.Types as P
 
 import IOUtil
 import FilePaths
-import Network.Mattermost (Hostname, Port)
 import Network.Mattermost.Types
 import Network.Mattermost.Lenses
 import Types

--- a/src/State.hs
+++ b/src/State.hs
@@ -60,6 +60,7 @@ module State
   -- * Working with users
   , handleNewUser
   , updateStatus
+  , handleTypingUser
 
   -- * Startup/reconnect management
   , refreshChannelsAndUsers
@@ -130,6 +131,7 @@ import           Data.Maybe (maybeToList, isJust, catMaybes, isNothing)
 import           Data.Monoid ((<>))
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import           Data.Time (getCurrentTime)
 import qualified Data.Vector as V
 import qualified Data.Foldable as F
 import           Graphics.Vty (outputIface)
@@ -1907,3 +1909,8 @@ handleNewUser newUserId = doAsyncMM Normal getUserInfo updateUserState
               do csUsers %= addUser newUserId uInfo
                  csNames . cnUsers %= (sort . ((newUser^.userUsernameL):))
                  csNames . cnToUserId . at (newUser^.userUsernameL) .= Just newUserId
+
+handleTypingUser :: UserId -> ChannelId -> MH ()
+handleTypingUser uId cId = do
+  ts <- liftIO getCurrentTime -- get time now
+  csChannels %= modifyChannelById cId (addChannelTypingUser uId ts)

--- a/src/State.hs
+++ b/src/State.hs
@@ -1912,5 +1912,7 @@ handleNewUser newUserId = doAsyncMM Normal getUserInfo updateUserState
 
 handleTypingUser :: UserId -> ChannelId -> MH ()
 handleTypingUser uId cId = do
-  ts <- liftIO getCurrentTime -- get time now
-  csChannels %= modifyChannelById cId (addChannelTypingUser uId ts)
+  config <- use (csResources.crConfiguration)
+  when (configShowTypingIndicator config) $ do
+    ts <- liftIO getCurrentTime -- get time now
+    csChannels %= modifyChannelById cId (addChannelTypingUser uId ts)

--- a/src/State.hs
+++ b/src/State.hs
@@ -859,7 +859,7 @@ updateViewed = do
 -- update the viewed time to now for the newly selected channel.
 updateViewedChan :: ChannelId -> MH ()
 updateViewedChan cId = use csConnectionStatus >>= \case
-      Connected _ _ -> do
+      Connected -> do
           -- Only do this if we're connected to avoid triggering noisy exceptions.
           pId <- use csRecentChannel
           doAsyncChannelMM Preempt cId
@@ -1863,7 +1863,7 @@ sendMessage mode msg =
                 Disconnected -> do
                     let m = "Cannot send messages while disconnected."
                     postErrorMessage m
-                Connected _ _ -> do
+                Connected -> do
                     let myId   = st^.csMe.userIdL
                         chanId = st^.csCurrentChannelId
                         theTeamId = st^.csMyTeam.teamIdL

--- a/src/State.hs
+++ b/src/State.hs
@@ -1910,6 +1910,7 @@ handleNewUser newUserId = doAsyncMM Normal getUserInfo updateUserState
                  csNames . cnUsers %= (sort . ((newUser^.userUsernameL):))
                  csNames . cnToUserId . at (newUser^.userUsernameL) .= Just newUserId
 
+-- | Handle the typing events from the websocket to show the currently typing users on UI
 handleTypingUser :: UserId -> ChannelId -> MH ()
 handleTypingUser uId cId = do
   config <- use (csResources.crConfiguration)

--- a/src/State.hs
+++ b/src/State.hs
@@ -859,7 +859,7 @@ updateViewed = do
 -- update the viewed time to now for the newly selected channel.
 updateViewedChan :: ChannelId -> MH ()
 updateViewedChan cId = use csConnectionStatus >>= \case
-      Connected -> do
+      Connected _ _ -> do
           -- Only do this if we're connected to avoid triggering noisy exceptions.
           pId <- use csRecentChannel
           doAsyncChannelMM Preempt cId
@@ -1863,7 +1863,7 @@ sendMessage mode msg =
                 Disconnected -> do
                     let m = "Cannot send messages while disconnected."
                     postErrorMessage m
-                Connected -> do
+                Connected _ _ -> do
                     let myId   = st^.csMe.userIdL
                         chanId = st^.csCurrentChannelId
                         theTeamId = st^.csMyTeam.teamIdL

--- a/src/State/Editing.hs
+++ b/src/State/Editing.hs
@@ -20,6 +20,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Zipper as Z
 import qualified Data.Text.Zipper.Generic.Words as Z
+import           Data.Time (getCurrentTime)
 import           Graphics.Vty (Event(..), Key(..), Modifier(..))
 import           Lens.Micro.Platform
 import qualified System.Environment as Sys
@@ -220,8 +221,10 @@ sendUserTypingAction = do
         let pId = case st^.csEditState.cedEditMode of
                     Replying _ post -> Just $ postId post
                     _               -> Nothing
-            action = UserTyping (st^.csCurrentChannelId) pId
-        liftIO $ STM.atomically $ STM.writeTChan (st^.csWebsocketActionChan) action
+        liftIO $ do
+          now <- getCurrentTime
+          let action = UserTyping now (st^.csCurrentChannelId) pId
+          STM.atomically $ STM.writeTChan (st^.csWebsocketActionChan) action
       Disconnected -> return ()
 
 -- Kick off an async request to the spell checker for the current editor

--- a/src/State/Setup.hs
+++ b/src/State/Setup.hs
@@ -118,8 +118,6 @@ setupState logFile config requestChan eventChan = do
               Nothing -> interactiveTeamSelection (F.toList (initialLoadTeams initialLoad))
               Just t -> return t
 
-  quitCondition <- newEmptyMVar
-
   userStatusLock <- newEmptyMVar
   putMVar userStatusLock ()
 
@@ -154,8 +152,7 @@ setupState logFile config requestChan eventChan = do
                      Right t -> return t
 
   let cr = ChatResources session cd requestChan eventChan
-             slc (themeToAttrMap custTheme) quitCondition
-             userStatusLock config mempty prefs
+             slc (themeToAttrMap custTheme) userStatusLock config mempty prefs
 
   initializeState cr myTeam myUser
 
@@ -205,7 +202,8 @@ initializeState cr myTeam myUser = do
   -- * User status refresher
   startUserRefreshThread (cr^.crUserStatusLock) session requestChan
   -- * Refresher for users who are typing currently
-  startTypingUsersRefreshThread requestChan
+  when (configShowTypingIndicator (cr^.crConfiguration)) $
+    startTypingUsersRefreshThread requestChan
   -- * Timezone change monitor
   startTimezoneMonitorThread tz requestChan
   -- * Subprocess logger
@@ -213,11 +211,12 @@ initializeState cr myTeam myUser = do
   -- * Spell checker and spell check timer, if configured
   spResult <- maybeStartSpellChecker (cr^.crConfiguration) (cr^.crEventQueue)
 
+  waChan <- STM.newTChanIO
   let chanNames = mkChanNames myUser mempty chans
       chanIds = [ (chanNames ^. cnToChanId) HM.! i
                 | i <- chanNames ^. cnChans ]
       chanZip = Z.fromList chanIds
-      st = newState cr chanZip myUser myTeam tz hist spResult
+      st = newState cr chanZip myUser myTeam tz hist spResult waChan
              & csChannels %~ flip (foldr (uncurry addChannel)) msgs
              & csNames .~ chanNames
 

--- a/src/State/Setup.hs
+++ b/src/State/Setup.hs
@@ -204,6 +204,8 @@ initializeState cr myTeam myUser = do
   -- Start background worker threads:
   -- * User status refresher
   startUserRefreshThread (cr^.crUserStatusLock) session requestChan
+  -- * Refresher for users who are typing currently
+  startTypingUsersRefreshThread requestChan
   -- * Timezone change monitor
   startTimezoneMonitorThread tz requestChan
   -- * Subprocess logger

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -219,6 +219,7 @@ data Config = Config
   , configUnsafeUseHTTP             :: Bool
   , configChannelListWidth          :: Int
   , configShowOlderEdits            :: Bool
+  , configShowTypingIndicator       :: Bool
   , configAbsPath                   :: Maybe FilePath
   } deriving (Eq, Show)
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -160,7 +160,7 @@ import qualified Control.Monad.State as St
 import qualified Data.Foldable as F
 import qualified Data.Sequence as Seq
 import           Data.HashMap.Strict (HashMap)
-import           Data.Int (Int64)
+import           Data.Time (UTCTime)
 import           Data.Time.LocalTime.TimeZone.Series (TimeZoneSeries)
 import qualified Data.HashMap.Strict as HM
 import           Data.List (sort, partition, sortBy)
@@ -554,7 +554,7 @@ data PostListOverlayState = PostListOverlayState
   }
 
 data WebsocketAction =
-    UserTyping ChannelId (Maybe PostId)
+    UserTyping UTCTime ChannelId (Maybe PostId)
   -- | GetStatuses
   -- | GetStatusesByIds [UserId]
   deriving (Read, Show, Eq, Ord)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -553,8 +553,9 @@ data PostListOverlayState = PostListOverlayState
   , _postListSelected :: Maybe PostId
   }
 
+-- | Actions that can be sent on the websocket to the server.
 data WebsocketAction =
-    UserTyping UTCTime ChannelId (Maybe PostId)
+    UserTyping UTCTime ChannelId (Maybe PostId) -- ^ user typing in the input box
   -- | GetStatuses
   -- | GetStatusesByIds [UserId]
   deriving (Read, Show, Eq, Ord)


### PR DESCRIPTION
### Adds user typing status to the UI
- Adds per channel map to ChatState of users who are currently typing in the channel.
- Adds an UI element to show the names of users who are currently typing.
  - Shows user names if there are less than three users. Else says "several people".
- Adds an event handler for the websocket typing event to update the typing users maps.
- Adds a background thread to expire users from the typing users maps to remove the users who have stopped typing.

### Adds support for sending user_typing actions to server
- Sends the user typing actions to the server over websocket for notifying other users.
- ChatState now contains a TChan to which Websocket actions are pushed.
- when the websocket is connected in Connections.connectWebsockets, we loop forever, taking actions from the TChan in ChatState and sending them over the websocket.
- the user_typing actions are throttled so that they are sent to server only once in 2 seconds.

### Adds a config to toggle user typing indicator
- This config also toggles sending the user typing websocket actions.

Fixes Issue #343. Depends on https://github.com/matterhorn-chat/mattermost-api/pull/42.