### PR TITLE
Add caching to travis config for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ script:
 
 cache:
   directories:
-  - dist-newstyle
   - $HOME/.cabal
   - $HOME/.ghc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,10 @@ script:
  - bash install.sh
  - cabal sdist
 
+cache:
+  directories:
+  - dist-newstyle
+  - $HOME/.cabal
+  - $HOME/.ghc
+
 # EOF


### PR DESCRIPTION
Adds caching for cabal and ghc directories to reduce build time on travis. Reduces each job's build time from around 35 minutes to around 5 minutes.