### PR TITLE
Make get calls to server concurrent for faster startup

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -119,7 +119,8 @@ executable matterhorn
                      , skylighting          >= 0.3.3.1 && < 0.4
                      , timezone-olson       >= 0.1.7   && < 0.2
                      , timezone-series      >= 0.1.6.1 && < 0.2
-                     , aeson                >= 1.2.3.0 && < 1.3
+                     , aeson                >= 1.1     && < 1.3
+                     , async                >= 2.0     && < 2.2
   default-language:    Haskell2010
 
 test-suite test_messages

--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -119,7 +119,7 @@ executable matterhorn
                      , skylighting          >= 0.3.3.1 && < 0.4
                      , timezone-olson       >= 0.1.7   && < 0.2
                      , timezone-series      >= 0.1.6.1 && < 0.2
-                     , aeson                >= 1.1     && < 1.3
+                     , aeson                >= 1.2.3.0 && < 1.3
                      , async                >= 2.0     && < 2.2
   default-language:    Haskell2010
 

--- a/src/State.hs
+++ b/src/State.hs
@@ -281,6 +281,8 @@ updatePreference pref = do
 -- occurs.
 refreshChannelsAndUsers :: MH ()
 refreshChannelsAndUsers = do
+  -- The below code is a duplicate of mmGetAllChannelsWithDataForUser function,
+  -- which has been inlined here to gain a concurrency benefit.
   session <- use (csResources.crSession)
   myTeamId <- use (csMyTeam.teamIdL)
   myId <- use (csMe.userIdL)


### PR DESCRIPTION
- does this only for independent calls.
- inlines `mmGetAllChannelsWithDataForUser` into `refreshChannelsAndUsers` and makes all the get calls concurrent.