### PR TITLE
Close session on application quit

### DIFF
--- a/src/LastRunState.hs
+++ b/src/LastRunState.hs
@@ -70,8 +70,8 @@ lastRunStateFileMode = P.unionFileModes P.ownerReadMode P.ownerWriteMode
 
 -- | Writes the run state to a file. The file is specific to the current team.
 -- | Writes only if the current channel is an ordrinary or a private channel.
-writeLastRunState :: ChatState -> IO (Either String ())
-writeLastRunState cs = runExceptT . convertIOException $
+writeLastRunState :: ChatState -> IO ()
+writeLastRunState cs =
   when (cs^.csCurrentChannel.ccInfo.cdType `elem` [Ordinary, Private]) $ do
     let runState = toLastRunState cs
         tId      = cs^.csMyTeam.teamIdL

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,14 +4,10 @@ import           Prelude ()
 import           Prelude.Compat
 
 import           Data.Monoid ((<>))
-import           Lens.Micro.Platform
 import           System.Exit (exitFailure)
 
 import           Config
 import           Options
-import           Types
-import           InputHistory
-import           LastRunState
 import           App
 
 main :: IO ()
@@ -25,12 +21,4 @@ main = do
         Right c -> return c
 
     finalSt <- runMatterhorn opts config
-
-    writeHistory (finalSt^.csEditState.cedInputHistory)
-
-    -- Try to write the run state to a file. If it fails, just print the error
-    -- and do not exit with a failure status because the run state file is optional.
-    done <- writeLastRunState finalSt
-    case done of
-      Left err -> putStrLn $ "Error in writing last run state: " <> err
-      Right _  -> return ()
+    closeMatterhorn finalSt

--- a/src/State/Setup.hs
+++ b/src/State/Setup.hs
@@ -69,9 +69,9 @@ setupState logFile config requestChan eventChan = do
                 -- HTTP.
                 if (configUnsafeUseHTTP config)
                   then initConnectionDataInsecure (ciHostname cInfo)
-                         (fromIntegral (ciPort cInfo))
+                         (fromIntegral (ciPort cInfo)) defaultConnectionPoolConfig
                   else initConnectionData (ciHostname cInfo)
-                         (fromIntegral (ciPort cInfo))
+                         (fromIntegral (ciPort cInfo)) defaultConnectionPoolConfig
 
         let login = Login { username = ciUsername cInfo
                           , password = ciPassword cInfo


### PR DESCRIPTION
This is a companion PR to https://github.com/matterhorn-chat/mattermost-api/pull/44.
- Closes session on application quit to destroy the underlying HTTP connection pool
- Consolidates and moves application cleanup into `App.closeMatterhorn` function.