### PR TITLE
Optionally use nicknames as display names

### DIFF
--- a/src/Draw/ChannelList.hs
+++ b/src/Draw/ChannelList.hs
@@ -236,7 +236,9 @@ getDmChannels st height =
                        Nothing      -> userSigilFromInfo u
                        Just ("", _) -> userSigilFromInfo u
                        _            -> '»'  -- shows that user has a message in-progress
-                   uname = u^.uiName
+                   uname = if useNickname st
+                           then u^.uiNickName.non (u^.uiName)
+                           else u^.uiName
                    recent = maybe False (isRecentChannel st) m_chanId
                    m_chanId = channelIdByName (u^.uiName) st
                    unread = maybe False (hasUnread st) m_chanId

--- a/src/Draw/Messages.hs
+++ b/src/Draw/Messages.hs
@@ -31,7 +31,7 @@ nameForUserRef :: ChatState -> UserRef -> Maybe T.Text
 nameForUserRef st uref = case uref of
                            NoUser -> Nothing
                            UserOverride t -> Just t
-                           UserI uId -> usernameForUserId uId st
+                           UserI uId -> displaynameForUserId uId st
 
 -- | renderSingleMessage is the main message drawing function.
 --

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -58,6 +58,7 @@ onAppEvent WebsocketDisconnect = do
 onAppEvent WebsocketConnect = do
   csConnectionStatus .= Connected
   refreshChannelsAndUsers
+  refreshClientConfig
 onAppEvent BGIdle     = csWorkerIsBusy .= Nothing
 onAppEvent (BGBusy n) = csWorkerIsBusy .= Just n
 onAppEvent (WSEvent we) =

--- a/src/Types/Users.hs
+++ b/src/Types/Users.hs
@@ -17,6 +17,7 @@ module Types.Users
   , findUserById
   , findUserByName
   , findUserByDMChannelName
+  , findUserByNickname
   , noUsers, addUser, allUsers
   , modifyUserById
   , getDMChannelName
@@ -31,6 +32,7 @@ module Types.Users
   )
 where
 
+import           Data.Foldable            (find)
 import           Data.Semigroup ((<>), Max(..))
 import qualified Data.HashMap.Strict as HM
 import           Data.List (sort)
@@ -159,6 +161,14 @@ findUserByName allusers name =
   case filter ((== name) . _uiName . snd) $ HM.toList $ _ofUsers allusers of
     (usr : []) -> Just usr
     _ -> Nothing
+
+-- | Get the User information given the user's name.  This is an exact
+-- match on the nickname field, not necessarily the presented name.
+findUserByNickname :: [UserInfo] -> T.Text -> Maybe UserInfo
+findUserByNickname uList nick =
+  find (nickCheck nick) uList
+    where
+        nickCheck n = maybe False (== n) . _uiNickName
 
 -- | Extract a specific user from the collection and perform an
 -- endomorphism operation on it, then put it back into the collection.

--- a/src/Types/Users.hs
+++ b/src/Types/Users.hs
@@ -32,7 +32,7 @@ module Types.Users
   )
 where
 
-import           Data.Foldable            (find)
+import           Data.Foldable (find)
 import           Data.Semigroup ((<>), Max(..))
 import qualified Data.HashMap.Strict as HM
 import           Data.List (sort)


### PR DESCRIPTION
Based on the mattermost server settings use users' nicknames as display names
and fall back to using the mattermost username if a user has not set a
nickname. When enabled on the server, nicknames may also be used in tab completions. The behavior mimics that of the mattermost desktop client where the name filled in for the tab completion is the actual username. It feels a little odd, but that's how the official client does it so that's what I went with.

The limitation with this is that changes to the server setting for display name do not generate a websocket event and therefore matterhorn will not detect a change to the setting until it is restarted. The mattermost desktop client appears to get around this by sending RSTs on the mattermost sockets and re-initializing. In practice I suspect this setting is not changed very frequently and will not cause a problem for many matterhorn users.