### PR TITLE
GHC 8.4.1 support

### DIFF
--- a/src/State.hs
+++ b/src/State.hs
@@ -131,7 +131,6 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Sequence as Seq
 import           Data.List (sort, findIndex)
 import           Data.Maybe (isJust, fromJust, catMaybes, isNothing)
-import           Data.Monoid ((<>))
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import           Data.Time (getCurrentTime)
@@ -1295,12 +1294,14 @@ data PostProcessMessageAdd = NoAction
 
 instance Monoid PostProcessMessageAdd where
   mempty = NoAction
-  mappend NotifyUserAndServer _         = NotifyUserAndServer
-  mappend _ NotifyUserAndServer         = NotifyUserAndServer
-  mappend NotifyUser UpdateServerViewed = NotifyUserAndServer
-  mappend UpdateServerViewed NotifyUser = NotifyUserAndServer
-  mappend x NoAction                    = x
-  mappend _ x                           = x
+
+instance Semigroup PostProcessMessageAdd where
+  (<>) NotifyUserAndServer _         = NotifyUserAndServer
+  (<>) _ NotifyUserAndServer         = NotifyUserAndServer
+  (<>) NotifyUser UpdateServerViewed = NotifyUserAndServer
+  (<>) UpdateServerViewed NotifyUser = NotifyUserAndServer
+  (<>) x NoAction                    = x
+  (<>) _ x                           = x
 
 -- | postProcessMessageAdd performs the actual actions indicated by
 -- the corresponding input value.

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -217,7 +217,6 @@ import           Data.Time.LocalTime.TimeZone.Series (TimeZoneSeries)
 import qualified Data.HashMap.Strict as HM
 import           Data.List (sort, partition, sortBy)
 import           Data.Maybe
-import           Data.Monoid
 import qualified Data.Set as Set
 import           Lens.Micro.Platform ( at, makeLenses, lens, (&), (^.), (%~), (.~), (^?!), (.=)
                                      , (%=), (^?)

--- a/src/Types/DirectionalSeq.hs
+++ b/src/Types/DirectionalSeq.hs
@@ -11,10 +11,7 @@
 
 module Types.DirectionalSeq where
 
-
-import           Data.Monoid
 import qualified Data.Sequence as Seq
-
 
 data Chronological
 data Retrograde
@@ -26,9 +23,11 @@ data SeqDirection dir => DirectionalSeq dir a =
     DSeq { dseq :: Seq.Seq a }
          deriving (Show, Functor, Foldable, Traversable)
 
+instance SeqDirection a => Semigroup (DirectionalSeq a e) where
+    (<>) a b = DSeq $ dseq a <> dseq b
+
 instance SeqDirection a => Monoid (DirectionalSeq a e) where
     mempty = DSeq mempty
-    mappend a b = DSeq $ mappend (dseq a) (dseq b)
 
 onDirectedSeq :: SeqDirection dir => (Seq.Seq a -> Seq.Seq b)
               -> DirectionalSeq dir a -> DirectionalSeq dir b


### PR DESCRIPTION
This doesn't fix everything matterhorn related, just the modules.  There are dependencies that don't work out.  To test the changes I built with `cabal new-build --allow-newer`.

Would we want to maintain support for GHC < 8.4?  I dislike `-XCPP` myself.