### PR TITLE
Allow notifications via an external command

### DIFF
--- a/notify
+++ b/notify
@@ -14,7 +14,8 @@ message="${3?}"
 # First word is urgency for items where you are not mentioned, the second is
 # urgency for items where you are mentioned.  Use "none" to not be notified,
 # otherwise low, normal, critical are options
-notify_URGENCIES="none normal"
+notify_URGENCIES="normal normal"
+#notify_URGENCIES="none normal"
 # The desktop notification category
 notify_CATEGORY="im.received"
 # Notification header
@@ -24,7 +25,7 @@ notify_BODY="$message"
 
 getUrgencyHelper() {
     shift "$mentioned"
-    printf '%s' "$1"
+    echo "$1"
 }
 
 getUrgency() {

--- a/notify
+++ b/notify
@@ -1,0 +1,37 @@
+#!/bin/sh
+#############################################################
+# Sample shell-script for using notify-send with matterhorn #
+#############################################################
+
+# Positional parameters
+mentioned="${1?}"
+sender="${2?}"
+message="${3?}"
+
+# Script options
+
+# notify_URGENCIES
+# First word is urgency for items where you are not mentioned, the second is
+# urgency for items where you are mentioned.  Use "none" to not be notified,
+# otherwise low, normal, critical are options
+notify_URGENCIES="none normal"
+# The desktop notification category
+notify_CATEGORY="im.received"
+# Notification header
+notify_HEAD="Matterhorn message from $sender"
+# Notification body
+notify_BODY="$message"
+
+getUrgencyHelper() {
+    shift "$mentioned"
+    printf '%s' "$1"
+}
+
+getUrgency() {
+    # we are using arguments as a poor-mans bash array for portability
+    # shellcheck disable=SC2086
+    getUrgencyHelper $notify_URGENCIES
+}
+
+test "$(getUrgency)" = "none" ||
+    notify-send -u "$(getUrgency)" -c "$notify_CATEGORY" "$notify_HEAD" "$notify_BODY"

--- a/sample-config.ini
+++ b/sample-config.ini
@@ -111,6 +111,10 @@
 # Default is False
 # activityBell = False
 
+# Notification script control: run a notification script whenever a new message
+# arrives.  See the "notify" script for an example linux notification script.
+# activityNotifyCommand = /path/to/notify
+
 # Background activity display: Matterhorn communicates with the
 # Mattermost server using asynchronous background thread processing.
 # This parameter can be used to enable a visual display of when and

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -55,7 +55,7 @@ fromIni = do
       (configShowTypingIndicator defaultConfig)
     configEnableAspell <- fieldFlagDef "enableAspell"
       (configEnableAspell defaultConfig)
-    configActivityNotifyCmd <- fieldMb "activityNotifyCmd"
+    configActivityNotifyCommand <- fieldMb "activityNotifyCommand"
     configActivityBell <- fieldFlagDef "activityBell"
       (configActivityBell defaultConfig)
     configHyperlinkingMode <- fieldFlagDef "hyperlinkURLs"
@@ -121,7 +121,7 @@ defaultConfig =
            , configSmartBacktick             = True
            , configURLOpenCommand            = Nothing
            , configURLOpenCommandInteractive = False
-           , configActivityNotifyCmd         = Nothing
+           , configActivityNotifyCommand     = Nothing
            , configActivityBell              = False
            , configShowBackground            = Disabled
            , configShowMessagePreview        = False

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -55,6 +55,7 @@ fromIni = do
       (configShowTypingIndicator defaultConfig)
     configEnableAspell <- fieldFlagDef "enableAspell"
       (configEnableAspell defaultConfig)
+    configActivityNotifyCmd <- fieldMb "activityNotifyCmd"
     configActivityBell <- fieldFlagDef "activityBell"
       (configActivityBell defaultConfig)
     configHyperlinkingMode <- fieldFlagDef "hyperlinkURLs"
@@ -120,6 +121,7 @@ defaultConfig =
            , configSmartBacktick             = True
            , configURLOpenCommand            = Nothing
            , configURLOpenCommandInteractive = False
+           , configActivityNotifyCmd         = Nothing
            , configActivityBell              = False
            , configShowBackground            = Disabled
            , configShowMessagePreview        = False

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -268,7 +268,7 @@ data Config = Config
   , configSmartBacktick             :: Bool
   , configURLOpenCommand            :: Maybe Text
   , configURLOpenCommandInteractive :: Bool
-  , configActivityNotifyCmd         :: Maybe T.Text
+  , configActivityNotifyCommand     :: Maybe T.Text
   , configActivityBell              :: Bool
   , configShowBackground            :: BackgroundInfo
   , configShowMessagePreview        :: Bool

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -268,6 +268,7 @@ data Config = Config
   , configSmartBacktick             :: Bool
   , configURLOpenCommand            :: Maybe Text
   , configURLOpenCommandInteractive :: Bool
+  , configActivityNotifyCmd         :: Maybe T.Text
   , configActivityBell              :: Bool
   , configShowBackground            :: BackgroundInfo
   , configShowMessagePreview        :: Bool


### PR DESCRIPTION
This adds the configuration field `activityNotifyCmd` which can be set to a shell command that takes the following 3 positional arguments:

1. "1"/"0" if the user was/was not mentioned
2. The username of the sender
3. The text of the message

The shell command is only called for new messages, not for messages read from the backlog.