### PR TITLE
Talky.io doesn't like '/' and perhaps other base64 symbols

### DIFF
--- a/scripts/talky
+++ b/scripts/talky
@@ -3,7 +3,9 @@
 BASE_URL="https://talky.io"
 
 base64enc() {
-    if [[ -x $(which openssl) ]] ; then
+    if [[ -x $(which shasum) ]] ; then
+        retval=$(echo $1 | shasum | sed 's/ .*//g')
+    elif [[ -x $(which openssl) ]] ; then
         retval=$(echo $1 | openssl enc -base64 | sed 's/\//x/g' | sed 's/+/x/g' | sed 's/=/x/g')
     elif [[ -x $(which base64) ]] ; then
         retval=$(echo $1 | base64 | sed 's/\//x/g' | sed 's/+/x/g' | sed 's/=/x/g')

--- a/scripts/talky
+++ b/scripts/talky
@@ -4,9 +4,9 @@ BASE_URL="https://talky.io"
 
 base64enc() {
     if [[ -x $(which openssl) ]] ; then
-        retval=$(echo $1 | openssl enc -base64)
+        retval=$(echo $1 | openssl enc -base64 | sed 's/\//x/g' | sed 's/+/x/g' | sed 's/=/x/g')
     elif [[ -x $(which base64) ]] ; then
-        retval=$(echo $1 | base64)
+        retval=$(echo $1 | base64 | sed 's/\//x/g' | sed 's/+/x/g' | sed 's/=/x/g')
     else
         echo "Unable to base64 encode, install base64?"
         exit


### PR DESCRIPTION
It isn't surprising '/' is a problem. It is surprising it is silently a problem and both users end up in a chat that is (evidently) non-joinable.