### PR TITLE
Direct channel expiration days option

### DIFF
--- a/sample-config.ini
+++ b/sample-config.ini
@@ -150,6 +150,11 @@
 # Default: True
 # showChannelList = False
 
+# How many days to keep a direct channel in the channel list after the 
+# last message.
+# Default: 7
+# directChannelExpirationDays = 14
+
 # Whether to enable the spell checker if "aspell" is present on the
 # system.
 # Default: False

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -105,6 +105,8 @@ fromIni = do
                   pure Nothing
     configUnsafeUseHTTP <-
       fieldFlagDef "unsafeUseUnauthenticatedConnection" False
+    configDirectChannelExpirationDays <- fieldDefOf "directChannelExpirationDays" number
+      (configDirectChannelExpirationDays defaultConfig)
 
     let configAbsPath = Nothing
         configUserKeys = mempty
@@ -151,34 +153,35 @@ isQuoted t =
 
 defaultConfig :: Config
 defaultConfig =
-    Config { configAbsPath                   = Nothing
-           , configUser                      = Nothing
-           , configHost                      = Nothing
-           , configTeam                      = Nothing
-           , configPort                      = defaultPort
-           , configPass                      = Nothing
-           , configTimeFormat                = Nothing
-           , configDateFormat                = Nothing
-           , configTheme                     = Nothing
-           , configThemeCustomizationFile    = Nothing
-           , configSmartBacktick             = True
-           , configURLOpenCommand            = Nothing
-           , configURLOpenCommandInteractive = False
-           , configActivityNotifyCommand     = Nothing
-           , configActivityBell              = False
-           , configShowBackground            = Disabled
-           , configShowMessagePreview        = False
-           , configShowChannelList           = True
-           , configEnableAspell              = False
-           , configAspellDictionary          = Nothing
-           , configUnsafeUseHTTP             = False
-           , configChannelListWidth          = 20
-           , configLogMaxBufferSize          = 200
-           , configShowOlderEdits            = True
-           , configUserKeys                  = mempty
-           , configShowTypingIndicator       = False
-           , configHyperlinkingMode          = True
-           , configSyntaxDirs                = []
+    Config { configAbsPath                     = Nothing
+           , configUser                        = Nothing
+           , configHost                        = Nothing
+           , configTeam                        = Nothing
+           , configPort                        = defaultPort
+           , configPass                        = Nothing
+           , configTimeFormat                  = Nothing
+           , configDateFormat                  = Nothing
+           , configTheme                       = Nothing
+           , configThemeCustomizationFile      = Nothing
+           , configSmartBacktick               = True
+           , configURLOpenCommand              = Nothing
+           , configURLOpenCommandInteractive   = False
+           , configActivityNotifyCommand       = Nothing
+           , configActivityBell                = False
+           , configShowBackground              = Disabled
+           , configShowMessagePreview          = False
+           , configShowChannelList             = True
+           , configEnableAspell                = False
+           , configAspellDictionary            = Nothing
+           , configUnsafeUseHTTP               = False
+           , configChannelListWidth            = 20
+           , configLogMaxBufferSize            = 200
+           , configShowOlderEdits              = True
+           , configUserKeys                    = mempty
+           , configShowTypingIndicator         = False
+           , configHyperlinkingMode            = True
+           , configSyntaxDirs                  = []
+           , configDirectChannelExpirationDays = 7
            }
 
 findConfig :: Maybe FilePath -> IO (Either String Config)

--- a/src/State/Channels.hs
+++ b/src/State/Channels.hs
@@ -103,7 +103,8 @@ updateSidebar = do
     us <- getUsers
     prefs <- use (csResources.crUserPreferences)
     now <- liftIO getCurrentTime
-    csFocus %= Z.updateList (mkChannelZipperList now cconfig prefs cs us)
+    config <- use (csResources.crConfiguration)
+    csFocus %= Z.updateList (mkChannelZipperList now config cconfig prefs cs us)
 
     -- Send the new zipper to the status update thread so that we can
     -- fetch the statuses for the users in the new sidebar.

--- a/src/State/Setup.hs
+++ b/src/State/Setup.hs
@@ -261,7 +261,7 @@ initializeState cr myTeam me = do
   -- End thread startup ----------------------------------------------
 
   now <- getCurrentTime
-  let chanIds = mkChannelZipperList now Nothing (cr^.crUserPreferences) clientChans noUsers
+  let chanIds = mkChannelZipperList now (cr^.crConfiguration) Nothing (cr^.crUserPreferences) clientChans noUsers
       chanZip = Z.fromList chanIds
       clientChans = foldr (uncurry addChannel) noChannels chanPairs
       startupState =


### PR DESCRIPTION
This adds the configuration option "directChannelExpirationDays" which is set by default to 7.

This option allows users to keep direct channels in the channel list for longer than the default number of days.