### PR TITLE
fix osx compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 # https://github.com/hvr/multi-ghc-travis
 language: c
 sudo: false
+os:
+  - osx
+  - linux
 
 matrix:
   include:

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,16 @@
 
 set -e
 
+command_exists () {
+  type "$1" &> /dev/null ;
+}
+
+if [[ "$OSTYPE" = darwin* ]]; then
+  command_exists cabal || brew install cabal-install
+  cabal update
+  cabal install tasty-quickcheck
+fi
+
 HERE=$(cd `dirname $0`; pwd)
 cd $HERE
 cabal new-build -j --enable-tests


### PR DESCRIPTION
I manage compile matterhorn on osx by amending the `build.sh` script.