### PR TITLE
Weaken the stm dependency to allow stm-2.5.0.0, which ships with GHC …

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -131,7 +131,7 @@ executable matterhorn
                      , connection           >= 0.2    && < 0.3
                      , text                 >= 1.2    && < 1.3
                      , bytestring           >= 0.10   && < 0.11
-                     , stm                  >= 2.4    && < 2.5
+                     , stm                  >= 2.4    && < 2.6
                      , config-ini           >= 0.2.2.0 && < 0.3
                      , process              >= 1.4    && < 1.7
                      , microlens-platform   >= 0.3    && < 0.4
@@ -202,7 +202,7 @@ test-suite test_messages
                     , mtl                  >= 2.2    && < 2.3
                     , process              >= 1.4    && < 1.7
                     , quickcheck-text      >= 0.1    && < 0.2
-                    , stm                  >= 2.4    && < 2.5
+                    , stm                  >= 2.4    && < 2.6
                     , strict               >= 0.3    && < 0.4
                     , string-conversions   >= 0.4    && < 0.5
                     , tasty                >= 0.11   && < 1.3


### PR DESCRIPTION
As the commit says, this weakens the `stm` requirements to allow 2.5.0.0, which is distributed (at least by `brew`) with GHC 8.6.3. 