### PR TITLE
Delay FileBrowser init until needed

### DIFF
--- a/src/App.hs
+++ b/src/App.hs
@@ -17,7 +17,7 @@ import           Network.Mattermost
 
 import           Config
 import           Draw
-import           Events
+import qualified Events
 import           IOUtil
 import           InputHistory
 import           LastRunState
@@ -46,7 +46,7 @@ app = App
       ViewMessage                   -> Nothing
       ShowHelp _                    -> Nothing
       UrlSelect                     -> Nothing
-  , appHandleEvent  = onEvent
+  , appHandleEvent  = Events.onEvent
   , appStartEvent   = return
   , appAttrMap      = (^.csResources.crTheme)
   }

--- a/src/Draw/ManageAttachments.hs
+++ b/src/Draw/ManageAttachments.hs
@@ -7,10 +7,11 @@ import           Prelude ()
 import           Prelude.MH
 
 import           Brick
-import           Brick.Widgets.List
-import           Brick.Widgets.Center
 import           Brick.Widgets.Border
+import           Brick.Widgets.Center
 import qualified Brick.Widgets.FileBrowser as FB
+import           Brick.Widgets.List
+import           Data.Maybe ( fromJust )
 
 import           Types
 import           Types.KeyEvents
@@ -58,4 +59,7 @@ drawFileBrowser st =
     hLimit 60 $
     vLimit 20 $
     borderWithLabel (txt "Attach File") $
-    FB.renderFileBrowser True (st^.csEditState.cedFileBrowser)
+    -- invariant: cedFileBrowser is not Nothing if appMode is
+    -- ManageAttachmentsBrowseFiles, and that is the only way to reach
+    -- this code, ergo the fromJust.
+    FB.renderFileBrowser True $ fromJust (st^.csEditState.cedFileBrowser)

--- a/src/State/Attachments.hs
+++ b/src/State/Attachments.hs
@@ -48,6 +48,6 @@ showAttachmentFileBrowser :: MH ()
 showAttachmentFileBrowser = do
     config <- use (csResources.crConfiguration)
     filePath <- liftIO $ defaultAttachmentsPath config
-    browser <- liftIO $ FB.newFileBrowser FB.selectNonDirectories AttachmentFileBrowser filePath
+    browser <- liftIO $ Just <$> FB.newFileBrowser FB.selectNonDirectories AttachmentFileBrowser filePath
     csEditState.cedFileBrowser .= browser
     setMode ManageAttachmentsBrowseFiles

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -938,8 +938,12 @@ data ChatEditState =
                   , _cedAttachmentList :: List Name AttachmentData
                   -- ^ The list of attachments to be uploaded with the
                   -- post being edited.
-                  , _cedFileBrowser :: FB.FileBrowser Name
+                  , _cedFileBrowser :: Maybe (FB.FileBrowser Name)
                   -- ^ The browser for selecting attachment files.
+                  -- This is a Maybe because the instantiation of the
+                  -- FileBrowser causes it to read and ingest the
+                  -- target directory, so this action is deferred
+                  -- until the browser is needed.
                   }
 
 -- | An attachment.
@@ -952,8 +956,7 @@ data AttachmentData =
 -- | We can initialize a new 'ChatEditState' value with just an edit
 -- history, which we save locally.
 emptyEditState :: InputHistory -> Maybe (Aspell, IO ()) -> IO ChatEditState
-emptyEditState hist sp = do
-    browser <- FB.newFileBrowser FB.selectNonDirectories AttachmentFileBrowser Nothing
+emptyEditState hist sp =
     return ChatEditState { _cedEditor               = editor MessageInput Nothing ""
                          , _cedEphemeral            = defaultEphemeralEditState
                          , _cedInputHistory         = hist
@@ -964,7 +967,7 @@ emptyEditState hist sp = do
                          , _cedAutocomplete         = Nothing
                          , _cedAutocompletePending  = Nothing
                          , _cedAttachmentList       = list AttachmentList mempty 1
-                         , _cedFileBrowser          = browser
+                         , _cedFileBrowser          = Nothing
                          }
 
 -- | A 'RequestChan' is a queue of operations we have to perform in the


### PR DESCRIPTION
The FileBrowser widget will perform a directory scan when it is initialized.  This was inadvertently discovered when researching https://github.com/jtdaugherty/brick/issues/251.  This change is not strictly needed, but this defers processing until it is actually needed (if ever) and should therefore facilitate improved startup time and remove potentially unneeded IO activity.

The downside of this change is that internally there are places where the state cannot be modified and there is an expectation of the existence of a FileBrowser object in accordance with the current mode value (particularly in the Draw functionality).  A future improvement might be to use the non-Nothing value of the FileBrowser Widget entry in the state as the mode indicator, but the impact and appropriateness of this elsewhere would need to be researched; that is left for future work.