### PR TITLE
Remove TeamId parameter from async API

### DIFF
--- a/src/State/Async.hs
+++ b/src/State/Async.hs
@@ -123,7 +123,7 @@ doAsyncWithIO prio st act = do
 -- main (brick) thread.
 doAsyncMM :: AsyncPriority
           -- ^ the priority for this async operation
-          -> (Session -> TeamId -> IO a)
+          -> (Session -> IO a)
           -- ^ the async MM channel-based IO operation
           -> (a -> Maybe (MH ()))
           -- ^ function to process the results in brick event handling
@@ -131,9 +131,8 @@ doAsyncMM :: AsyncPriority
           -> MH ()
 doAsyncMM prio mmOp eventHandler = do
   session <- getSession
-  tId <- gets myTeamId
   doAsyncWith prio $ do
-    r <- mmOp session tId
+    r <- mmOp session
     return $ eventHandler r
 
 -- | Helper type for a function to perform an asynchronous MM operation
@@ -143,7 +142,7 @@ type DoAsyncChannelMM a =
     -- ^ the priority for this async operation
     -> ChannelId
     -- ^ The channel
-    -> (Session -> TeamId -> ChannelId -> IO a)
+    -> (Session -> ChannelId -> IO a)
     -- ^ the asynchronous Mattermost channel-based IO operation
     -> (ChannelId -> a -> Maybe (MH ()))
     -- ^ function to process the results in brick event handling context
@@ -154,7 +153,7 @@ type DoAsyncChannelMM a =
 -- an MH () context in the main (brick) thread.
 doAsyncChannelMM :: DoAsyncChannelMM a
 doAsyncChannelMM prio cId mmOp eventHandler =
-  doAsyncMM prio (\s t -> mmOp s t cId) (eventHandler cId)
+  doAsyncMM prio (\s -> mmOp s cId) (eventHandler cId)
 
 -- | Use this convenience function if no operation needs to be
 -- performed in the MH state after an async operation completes.

--- a/src/State/MessageSelect.hs
+++ b/src/State/MessageSelect.hs
@@ -220,7 +220,7 @@ deleteSelectedMessage = do
             case msg^.mOriginalPost of
               Just p ->
                   doAsyncChannelMM Preempt cId
-                      (\s _ _ -> MM.mmDeletePost (postId p) s)
+                      (\s _ -> MM.mmDeletePost (postId p) s)
                       (\_ _ -> Just $ do
                           csEditState.cedEditMode .= NewPost
                           setMode Main)

--- a/src/State/Messages.hs
+++ b/src/State/Messages.hs
@@ -543,7 +543,7 @@ addMessageToState doFetchMentionedUsers fetchAuthor newPostData = do
                             case getMessageForPostId st parentId of
                                 Nothing -> do
                                     doAsyncChannelMM Preempt cId
-                                        (\s _ _ -> MM.mmGetThread parentId s)
+                                        (\s _ -> MM.mmGetThread parentId s)
                                         (\_ p -> Just $ updatePostMap p)
                                 _ -> return ()
                         _ -> return ()
@@ -702,7 +702,7 @@ asyncFetchMoreMessages = do
             addTrailingGap = MM.postQueryBefore query == Nothing &&
                              MM.postQueryPage query == Just 0
         in doAsyncChannelMM Preempt cId
-               (\s _ c -> MM.mmGetPostsForChannel c query s)
+               (\s c -> MM.mmGetPostsForChannel c query s)
                (\c p -> Just $ do
                    pp <- addObtainedMessages c (-pageAmount) addTrailingGap p
                    postProcessMessageAdd pp
@@ -754,7 +754,7 @@ asyncFetchMessagesForGap cId gapMessage =
         addTrailingGap = MM.postQueryBefore query == Nothing &&
                          MM.postQueryPage query == Just 0
     in doAsyncChannelMM Preempt cId
-       (\s _ c -> MM.mmGetPostsForChannel c query s)
+       (\s c -> MM.mmGetPostsForChannel c query s)
        (\c p -> Just $ do
            void $ addObtainedMessages c (-pageAmount) addTrailingGap p
            mh $ invalidateCacheEntry (ChannelMessages cId))
@@ -784,7 +784,7 @@ asyncFetchMessagesSurrounding cId pId = do
         reqAmt = 5  -- both before and after
     doAsyncChannelMM Preempt cId
       -- first get some messages before the target, no overlap
-      (\s _ c -> MM.mmGetPostsForChannel c query s)
+      (\s c -> MM.mmGetPostsForChannel c query s)
       (\c p -> Just $ do
           let last2ndId = secondToLastPostId p
           void $ addObtainedMessages c (-reqAmt) False p
@@ -798,7 +798,7 @@ asyncFetchMessagesSurrounding cId pId = do
                        , MM.postQueryPerPage = Just $ reqAmt + 2
                        }
           doAsyncChannelMM Preempt cId
-            (\s' _ c' -> MM.mmGetPostsForChannel c' query' s')
+            (\s' c' -> MM.mmGetPostsForChannel c' query' s')
             (\c' p' -> Just $ do
                 void $ addObtainedMessages c' (reqAmt + 2) False p'
                 mh $ invalidateCacheEntry (ChannelMessages cId)
@@ -832,7 +832,7 @@ fetchVisibleIfNeeded = do
                 finalQuery = case rel'pId of
                                Just (MessagePostId pid) -> query { MM.postQueryBefore = Just pid }
                                _ -> query
-                op = \s _ c -> MM.mmGetPostsForChannel c finalQuery s
+                op = \s c -> MM.mmGetPostsForChannel c finalQuery s
                 addTrailingGap = MM.postQueryBefore finalQuery == Nothing &&
                                  MM.postQueryPage finalQuery == Just 0
             in when ((not $ chan^.ccContents.cdFetchPending) && gapInDisplayable) $ do

--- a/src/State/Reactions.hs
+++ b/src/State/Reactions.hs
@@ -26,7 +26,7 @@ asyncFetchReactionsForPost :: ChannelId -> Post -> MH ()
 asyncFetchReactionsForPost cId p
   | not (p^.postHasReactionsL) = return ()
   | otherwise = doAsyncChannelMM Normal cId
-        (\s _ _ -> fmap toList (mmGetReactionsForPost (p^.postIdL) s))
+        (\s _ -> fmap toList (mmGetReactionsForPost (p^.postIdL) s))
         (\_ rs -> Just $ addReactions cId rs)
 
 addReactions :: ChannelId -> [Reaction] -> MH ()

--- a/src/State/Users.hs
+++ b/src/State/Users.hs
@@ -28,7 +28,7 @@ import           State.Common
 handleNewUsers :: Seq UserId -> MH () -> MH ()
 handleNewUsers newUserIds after = do
     doAsyncMM Preempt getUserInfo addNewUsers
-    where getUserInfo session _ =
+    where getUserInfo session =
               do nUsers <- MM.mmGetUsersByIds newUserIds session
                  let usrInfo u = userInfoFromUser u True
                      usrList = toList nUsers


### PR DESCRIPTION
This was some prework for #547 but also is minor cleanup that shouldn't hurt anything. It turns out that the `TeamId` parameter in the async machinery is never used—I assume this is because the `TeamId` was IIRC more widely used in v3 of the Mattermost API but became less common in v4, so this API never quite got simplified accordingly.