### PR TITLE
Allow submodules be cloned without a GitHub SSH key

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "submodules/aspell-pipe"]
 	path = submodules/aspell-pipe
-	url = git@github.com:matterhorn-chat/aspell-pipe.git
+	url = https://github.com/matterhorn-chat/aspell-pipe.git
 [submodule "submodules/mattermost-api-qc"]
 	path = submodules/mattermost-api-qc
-	url = git@github.com:matterhorn-chat/mattermost-api-qc.git
+	url = https://github.com/matterhorn-chat/mattermost-api-qc.git
 [submodule "submodules/mattermost-api"]
 	path = submodules/mattermost-api
-	url = git@github.com:matterhorn-chat/mattermost-api.git
+	url = https://github.com/matterhorn-chat/mattermost-api.git


### PR DESCRIPTION
I am building matterhorn in a Docker Image and would like to do that without adding a ssh key to a github account.