### PR TITLE
Allow connecting to a server running in a subdirectory

### DIFF
--- a/docs/sample-config.ini
+++ b/docs/sample-config.ini
@@ -24,6 +24,12 @@
 #
 # port: 443
 
+# Server URL path. If the Mattermost server is located at
+# https://example.com/mattermost then this would be set to
+# /mattermost. Optional. Defaults to empty string.
+#
+# urlPath: /path/to/server
+
 # Password command. Optional. If this and the password option are both
 # missing or give the wrong password, you'll be prompted on startup.
 #

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -71,6 +71,7 @@ fromIni = do
     configHost           <- fieldMbOf "host" stringField
     configTeam           <- fieldMbOf "team" stringField
     configPort           <- fieldDefOf "port" number (configPort defaultConfig)
+    configUrlPath        <- fieldMbOf "urlPath" stringField
     configChannelListWidth <- fieldDefOf "channelListWidth" number
                               (configChannelListWidth defaultConfig)
     configCpuUsagePolicy <- fieldDefOf "cpuUsagePolicy" cpuUsagePolicy
@@ -182,6 +183,7 @@ defaultConfig =
            , configHost                        = Nothing
            , configTeam                        = Nothing
            , configPort                        = defaultPort
+           , configUrlPath                     = Nothing
            , configPass                        = Nothing
            , configTimeFormat                  = Nothing
            , configDateFormat                  = Nothing
@@ -303,5 +305,6 @@ getCredentials config = do
 
     ConnectionInfo <$> configHost config
                    <*> (pure $ configPort config)
+                   <*> configUrlPath config
                    <*> configUser config
                    <*> (pure passStr)

--- a/src/Login.hs
+++ b/src/Login.hs
@@ -79,7 +79,7 @@ import           Network.Mattermost.Endpoints ( mmLogin )
 import           Markdown
 import           Themes ( clientEmphAttr )
 import           Types ( ConnectionInfo(..)
-                       , ciPassword, ciUsername, ciHostname
+                       , ciPassword, ciUsername, ciHostname, ciUrlPath
                        , ciPort, AuthenticationException(..)
                        , LogManager, LogCategory(..), ioLogWithManager
                        )
@@ -89,6 +89,7 @@ import           Types ( ConnectionInfo(..)
 data Name =
     Hostname
     | Port
+    | UrlPath
     | Username
     | Password
     deriving (Ord, Eq, Show)
@@ -350,6 +351,8 @@ mkForm =
                    editHostname ciHostname Hostname
                , label "Server port:" @@=
                    editShowableField ciPort Port
+               , label "Server URL path:" @@=
+                   editTextField ciUrlPath UrlPath (Just 1)
                , label "Username:" @@=
                    editTextField ciUsername Username (Just 1)
                , label "Password:" @@=

--- a/src/Login.hs
+++ b/src/Login.hs
@@ -186,7 +186,7 @@ loginWorker setLogger logMgr connTy requestChan respChan = forever $ do
                               , password = connInfo^.ciPassword
                               }
 
-            cd <- fmap setLogger $ initConnectionData (connInfo^.ciHostname) (fromIntegral (connInfo^.ciPort)) connTy poolCfg
+            cd <- fmap setLogger $ initConnectionData (connInfo^.ciHostname) (fromIntegral (connInfo^.ciPort)) (connInfo^.ciUrlPath) connTy poolCfg
 
             result <- convertLoginExceptions $ mmLogin cd login
             case result of

--- a/src/State/Setup.hs
+++ b/src/State/Setup.hs
@@ -40,10 +40,11 @@ import qualified Zipper as Z
 
 
 incompleteCredentials :: Config -> ConnectionInfo
-incompleteCredentials config = ConnectionInfo hStr (configPort config) uStr pStr
+incompleteCredentials config = ConnectionInfo hStr (configPort config) dStr uStr pStr
     where
         hStr = maybe "" id $ configHost config
         uStr = maybe "" id $ configUser config
+        dStr = maybe "" id $ configUrlPath config
         pStr = case configPass config of
             Just (PasswordString s) -> s
             _                       -> ""

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -40,6 +40,7 @@ module Types
   , entryIsDMEntry
   , ciHostname
   , ciPort
+  , ciUrlPath
   , ciUsername
   , ciPassword
   , Config(..)
@@ -355,6 +356,8 @@ data Config =
            -- ^ The team name to use when connecting.
            , configPort :: Int
            -- ^ The port to use when connecting.
+           , configUrlPath :: Maybe Text
+           -- ^ The server path to use when connecting.
            , configPass :: Maybe PasswordSource
            -- ^ The password source to use when connecting.
            , configTimeFormat :: Maybe Text
@@ -649,6 +652,7 @@ data AuthenticationException =
 data ConnectionInfo =
     ConnectionInfo { _ciHostname :: Text
                    , _ciPort     :: Int
+                   , _ciUrlPath  :: Text
                    , _ciUsername :: Text
                    , _ciPassword :: Text
                    }


### PR DESCRIPTION
Provides a configuration option and a field in the login form to specify the server URL path, allowing the client to connect to a Mattermost server running in a subdirectory, as described in #538. This PR depends on matterhorn-chat/mattermost-api#48.