### PR TITLE
consolidated login screen

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -177,6 +177,7 @@ executable matterhorn
                      , async                >= 2.2     && < 2.3
                      , uuid                 >= 1.3     && < 1.4
                      , random               >= 1.1     && < 1.2
+                     , network-uri          >= 2.6     && < 2.7
   default-language:    Haskell2010
 
 test-suite test_messages

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -7,6 +7,7 @@ module Config
   , findConfig
   , getCredentials
   , defaultConfig
+  , configConnectionType
   )
 where
 
@@ -15,7 +16,6 @@ import           Prelude.MH
 
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Class ( lift )
-import           Control.Monad.IO.Class ( liftIO )
 import           Data.Ini.Config
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
@@ -24,6 +24,7 @@ import           System.Directory ( makeAbsolute, getHomeDirectory )
 import           System.Environment ( getExecutablePath )
 import           System.FilePath ( (</>), takeDirectory, splitPath, joinPath )
 import           System.Process ( readProcess )
+import           Network.Mattermost.Types (ConnectionType(..))
 
 import           FilePaths
 import           IOUtil
@@ -304,7 +305,13 @@ getCredentials config = do
                     show (configPass config)
 
     ConnectionInfo <$> configHost config
-                   <*> (pure $ configPort config)
+                   <*> pure (configPort config)
                    <*> configUrlPath config
                    <*> configUser config
-                   <*> (pure passStr)
+                   <*> pure passStr
+                   <*> pure (configConnectionType config)
+
+configConnectionType :: Config -> ConnectionType
+configConnectionType config
+  | configUnsafeUseHTTP config = ConnectHTTP
+  | otherwise = ConnectHTTPS (configValidateServerCertificate config)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -43,6 +43,7 @@ module Types
   , ciUrlPath
   , ciUsername
   , ciPassword
+  , ciType
   , Config(..)
   , HelpScreen(..)
   , PasswordSource(..)
@@ -285,7 +286,7 @@ import qualified Data.HashMap.Strict as HM
 import           Data.List ( sortBy, nub, elemIndex )
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
-import           Data.Time.Clock ( UTCTime, getCurrentTime, addUTCTime )
+import           Data.Time.Clock ( getCurrentTime, addUTCTime )
 import           Data.UUID ( UUID )
 import qualified Data.Vector as Vec
 import           Lens.Micro.Platform ( at, makeLenses, lens, (%~), (^?!), (.=)
@@ -655,6 +656,7 @@ data ConnectionInfo =
                    , _ciUrlPath  :: Text
                    , _ciUsername :: Text
                    , _ciPassword :: Text
+                   , _ciType     :: ConnectionType
                    }
 
 -- | We want to continue referring to posts by their IDs, but we don't
@@ -1235,7 +1237,7 @@ data ChatState =
               , _csShowMessagePreview :: Bool
               -- ^ Whether to show the message preview area.
               , _csShowChannelList :: Bool
-              -- ^ Whether to show the channe list.
+              -- ^ Whether to show the channel list.
               , _csChannelSelectState :: ChannelSelectState
               -- ^ The state of the user's input and selection for
               -- channel selection mode.


### PR DESCRIPTION
Discussion on #574 

This preserves the existing configuration file format. The input field is validated using a URI parser and query and fragment parts are rejected

Examples of supported inputs:

- `mattermost.example.com`
- `mattermost.example.com:4343`
- `mattermost.example.com/one/two`
- `mattermost.example.com:4343/one/two`
