### PR TITLE
Enable token authentication

### DIFF
--- a/docs/sample-config.ini
+++ b/docs/sample-config.ini
@@ -24,8 +24,8 @@
 #
 # port: 443
 
-# Password command. Optional. If this and the password option are both
-# missing or give the wrong password, you'll be prompted on startup.
+# Password command. Optional. If this, the password option and token command
+# are all missing or give the wrong password, you'll be prompted on startup.
 #
 # You can also just use
 #
@@ -64,6 +64,19 @@
 # You can then set:
 #
 # passcmd: secret-tool lookup matterhorn password
+
+# Token command. Optional. If this is specified, the provided command will be
+# executed to obtain an OAUTH or personal access token that can be used instead
+# of username and password for authentication with the mattermost server. The
+# token command takes precedence over username and password configuration
+# options, i.e., when a token is specified username and password options are
+# ignored.
+#
+# Otherwise the token command functions just like the password command. Hence,
+# if you have obtained a personal access token and stored it in your keychain,
+# you can use it like this:
+#
+# tokencmd: secret-tool lookup matterhorn token
 
 # This optional setting controls how the client displays times. If it's
 # absent, you get the default behavior ("%R"). If it's present but

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -293,7 +293,7 @@ getConfig fp = do
                     output <- convertIOException (readProcess cmd rest "") `catchE`
                               (\e -> throwE $ "Could not execute token command: " <> e)
                     return $ Just $ T.pack (takeWhile (/= '\n') output)
-                Just (TokenString pass) -> error $ "getConfig: Token was provided as plain text. This is a bug!"
+                Just (TokenString _) -> error $ "getConfig: Token was provided as plain text. This is a bug!"
                 Nothing -> return Nothing
 
             return conf { configPass = PasswordString <$> actualPass

--- a/src/Login.hs
+++ b/src/Login.hs
@@ -82,7 +82,6 @@ import           Markdown
 import           Themes ( clientEmphAttr )
 import           Types ( ConnectionInfo(..)
                        , ConnectionInfoUsernamePassword(..)
-                       , ConnectionInfoToken(..)
                        , cipPassword, cipUsername, cipHostname, cipPort
                        , citToken, citHostname, citPort, getHostname, getPort, AuthenticationException(..)
                        , LogManager, LogCategory(..), ioLogWithManager

--- a/src/State/Setup.hs
+++ b/src/State/Setup.hs
@@ -40,7 +40,11 @@ import qualified Zipper as Z
 
 
 incompleteCredentials :: Config -> ConnectionInfo
-incompleteCredentials config = ConnectionInfo hStr (configPort config) uStr pStr
+incompleteCredentials config =
+    case configToken config of
+        Just (TokenString tok) -> Token (ConnectionInfoToken hStr (configPort config) tok)
+        Just (TokenCommand _) -> error $ "TokenCommand was not executed. This is a bug!"
+        Nothing -> UsernamePassword (ConnectionInfoUsernamePassword hStr (configPort config) uStr pStr)
     where
         hStr = maybe "" id $ configHost config
         uStr = maybe "" id $ configUser config


### PR DESCRIPTION
This is my attempt at resolving #515.

Since in the current situation we are using mattermost more and more at work, I just went ahead and implemented support for token authentication without more discussion in the issue. The current solution works for me for now, but of course I'm very much open to discussion on the specifics.

As far as I know, and as pointed out in #515, OAUTH and personal access tokens only differ in the way they are obtained and how long they are valid. So this approach would work for both. (Although the instance I use does not offer an option to obtain personal access tokens and I have only tested this with OAUTH tokens obtained from the cookies of my web browser. Somebody else should probably test this as well.)

In contrast to what was discussed in #515, I have only implemented the `tokencmd` config option for simplicity. As discussed there another option for reading the token from a file is (1.) questionable from a security point of view and (2.) can just be emulated using `tokencmd: cat /path/to/token/file`.

In terms of code I should point out that I have removed the function `getCredentials` instead of changing it as it wasn't used anywhere.

Finally, I have to admit that the last time I've really used haskell was in an undergraduate course at university so... If you have any requests for style changes I'm not offended in any way.