### PR TITLE
Use correct link to community server

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Get notified about new Matterhorn releases by following our Twitter account!
 # Chat With the Developers
 
 The Matterhorn developers hang out on the official Mattermost
-pre-release server. Stop by to get support and say hello!
+community server. Stop by to get support and say hello!
 
-[https://pre-release.mattermost.com/core/channels/matterhorn](https://pre-release.mattermost.com/core/channels/matterhorn)
+[https://community.mattermost.com/core/channels/matterhorn](https://community.mattermost.com/core/channels/matterhorn)
 
 # Quick Start
 


### PR DESCRIPTION
The README currently links to [pre-release.mattermost.com](pre-release.mattermost.com), which seems to be broken. The Mattermost developers [changed their documentation](https://github.com/mattermost/mattermost-server/pull/13379) a few months ago to link to [community.mattermost.com](community.mattermost.com), so we should probably do that too.