### PR TITLE
Correctly handle muted channels

### DIFF
--- a/src/Events.hs
+++ b/src/Events.hs
@@ -352,7 +352,6 @@ handleWSEvent we = do
         WMTeamDeleted -> return ()
         WMUserUpdated -> return ()
         WMLeaveTeam -> return ()
-        WMChannelMemberUpdated {} -> return ()
 
         -- We deliberately ignore these events:
         WMChannelCreated -> return ()

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -335,6 +335,14 @@ handleWSEvent we = do
             | Just cId <- webChannelId (weBroadcast we) -> handleChannelInvite cId
             | otherwise -> return ()
 
+        WMChannelMemberUpdated
+            | Just channelMember <- wepChannelMember $ weData we ->
+                  when (channelMemberUserId channelMember == myId) $
+                      updateChannelNotifyProps
+                      (channelMemberChannelId channelMember)
+                      (channelMemberNotifyProps channelMember)
+            | otherwise -> return ()
+
         -- We are pretty sure we should do something about these:
         WMAddedToTeam -> return ()
 

--- a/src/State/Channels.hs
+++ b/src/State/Channels.hs
@@ -47,6 +47,7 @@ module State.Channels
   , beginCurrentChannelDeleteConfirm
   , toggleChannelListVisibility
   , showChannelInSidebar
+  , updateChannelNotifyProps
   )
 where
 
@@ -1061,3 +1062,8 @@ beginCurrentChannelDeleteConfirm = do
         if chType /= Direct
             then setMode DeleteChannelConfirm
             else mhError $ GenericError "Direct message channels cannot be deleted."
+
+updateChannelNotifyProps :: ChannelId -> ChannelNotifyProps -> MH ()
+updateChannelNotifyProps cId notifyProps = do
+    mh $ invalidateCacheEntry ChannelSidebar
+    csChannel(cId).ccInfo.cdNotifyProps .= notifyProps

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -481,8 +481,10 @@ hasUnread' :: ClientChannel -> Bool
 hasUnread' chan = fromMaybe False $ do
     let info = _ccInfo chan
     lastViewTime <- _cdViewed info
-    return $ ((_cdUpdated info) > lastViewTime) ||
-             (isJust $ _cdEditedMessageThreshold info)
+    return $ _cdMentionCount info > 0 ||
+             (not (isMuted chan) &&
+              ((_cdUpdated info) > lastViewTime) ||
+              (isJust $ _cdEditedMessageThreshold info))
 
 mkChannelZipperList :: UTCTime
                     -> Config

--- a/src/Types/Channels.hs
+++ b/src/Types/Channels.hs
@@ -41,6 +41,7 @@ module Types.Channels
   , addChannelTypingUser
   -- * Notification settings
   , notifyPreference
+  , isMuted
   -- * Miscellaneous channel-related operations
   , canLeaveChannel
   , preferredChannelName

--- a/src/Types/Channels.hs
+++ b/src/Types/Channels.hs
@@ -20,7 +20,7 @@ module Types.Channels
   , cdViewed, cdNewMessageIndicator, cdEditedMessageThreshold, cdUpdated
   , cdName, cdDisplayName, cdHeader, cdPurpose, cdType
   , cdMentionCount, cdTypingUsers, cdDMUserId, cdChannelId
-  , cdSidebarShowOverride
+  , cdSidebarShowOverride, cdNotifyProps
   -- * Lenses created for accessing ChannelContents fields
   , cdMessages, cdFetchPending
   -- * Creating ClientChannel objects
@@ -240,11 +240,16 @@ makeLenses ''ChannelInfo
 makeLenses ''ClientChannel
 makeLenses ''EphemeralEditState
 
+isMuted :: ClientChannel -> Bool
+isMuted cc = cc^.ccInfo.cdNotifyProps.channelNotifyPropsMarkUnreadL ==
+             IsValue NotifyOptionMention
+
 notifyPreference :: User -> ClientChannel -> NotifyOption
 notifyPreference u cc =
-    case cc^.ccInfo.cdNotifyProps.channelNotifyPropsDesktopL of
-        IsValue v -> v
-        Default   -> (userNotifyProps u)^.userNotifyPropsDesktopL
+    if isMuted cc then NotifyOptionNone
+    else case cc^.ccInfo.cdNotifyProps.channelNotifyPropsDesktopL of
+             IsValue v -> v
+             Default   -> (userNotifyProps u)^.userNotifyPropsDesktopL
 
 -- ** Miscellaneous channel operations
 


### PR DESCRIPTION
This PR allows Matterhorn to properly handle muted channels. When a channel is muted, Matterhorn behaves as follows:
- Mentions will not trigger notifications. If there are unread mentions, the channel is highlighted like an unmuted channel with unread messages and no mentions, although the message count is still displayed.
- If there are no mentions, the channel is treated as having no unread messages. A muted channel with unread messages will have `(m)` in the place where the mention counter normally is.
- Since DMs are treated similarly to mentions, a muted DM channel will behave similarly to a regular channel (messages appear as regular unreads and do not cause notifications).

Muting a channel can be done with `/mute`, which is already a server command.