### PR TITLE
Add interface for editing channel notification preferences

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -111,6 +111,7 @@ executable matterhorn
                        Events.LeaveChannelConfirm
                        Events.DeleteChannelConfirm
                        Events.TabbedWindow
+                       Events.EditNotifyPrefs
                        Windows.ViewMessage
                        HelpTopics
                        KeyMap

--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -59,6 +59,7 @@ executable matterhorn
                        State.Logging
                        State.Messages
                        State.MessageSelect
+                       State.NotifyPrefs
                        State.PostListOverlay
                        State.ThemeListOverlay
                        State.ReactionEmojiListOverlay

--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -93,6 +93,7 @@ executable matterhorn
                        Draw.URLList
                        Draw.Util
                        Draw.TabbedWindow
+                       Draw.NotifyPrefs
                        InputHistory
                        IOUtil
                        Events

--- a/src/App.hs
+++ b/src/App.hs
@@ -48,6 +48,7 @@ app = App
       ViewMessage                   -> Nothing
       ShowHelp _ _                  -> Nothing
       UrlSelect                     -> Nothing
+      EditNotifyPrefs               -> Nothing
   , appHandleEvent  = Events.onEvent
   , appStartEvent   = return
   , appAttrMap      = (^.csResources.crTheme)

--- a/src/Command.hs
+++ b/src/Command.hs
@@ -33,6 +33,7 @@ import           State.PostListOverlay
 import           State.UserListOverlay
 import           State.ChannelListOverlay
 import           State.ThemeListOverlay
+import           State.NotifyPrefs
 import           State.Common ( postInfoMessage )
 import           State.Users
 import           Themes ( attrForUsername )
@@ -253,6 +254,9 @@ commandList =
 
   , Cmd "search" "Search for posts with given terms" (LineArg "terms") $
       enterSearchResultPostListMode
+
+  , Cmd "notify-prefs" "Edit channel notification preferences" NoArg $ \_ ->
+          enterEditNotifyPrefsMode
 
   ]
 

--- a/src/Draw.hs
+++ b/src/Draw.hs
@@ -6,7 +6,6 @@ import Prelude ()
 import Prelude.MH
 
 import Brick
-import Brick.Forms (renderForm)
 
 import Lens.Micro.Platform ( _2, singular, _Just )
 
@@ -21,6 +20,7 @@ import Draw.ChannelListOverlay
 import Draw.ReactionEmojiListOverlay
 import Draw.TabbedWindow
 import Draw.ManageAttachments
+import Draw.NotifyPrefs
 import Types
 
 
@@ -43,4 +43,4 @@ draw st =
         ViewMessage                -> drawTabbedWindow (st^.csViewedMessage.singular _Just._2) st : drawMain False st
         ManageAttachments          -> drawManageAttachments st
         ManageAttachmentsBrowseFiles -> drawManageAttachments st
-        EditNotifyPrefs            -> [renderForm (st^.csNotifyPrefs.singular _Just)]
+        EditNotifyPrefs            -> drawNotifyPrefs st : drawMain False st

--- a/src/Draw.hs
+++ b/src/Draw.hs
@@ -42,3 +42,4 @@ draw st =
         ViewMessage                -> drawTabbedWindow (st^.csViewedMessage.singular _Just._2) st : drawMain False st
         ManageAttachments          -> drawManageAttachments st
         ManageAttachmentsBrowseFiles -> drawManageAttachments st
+        EditNotifyPrefs            -> drawMain True st

--- a/src/Draw.hs
+++ b/src/Draw.hs
@@ -6,6 +6,7 @@ import Prelude ()
 import Prelude.MH
 
 import Brick
+import Brick.Forms (renderForm)
 
 import Lens.Micro.Platform ( _2, singular, _Just )
 
@@ -42,4 +43,4 @@ draw st =
         ViewMessage                -> drawTabbedWindow (st^.csViewedMessage.singular _Just._2) st : drawMain False st
         ManageAttachments          -> drawManageAttachments st
         ManageAttachmentsBrowseFiles -> drawManageAttachments st
-        EditNotifyPrefs            -> drawMain True st
+        EditNotifyPrefs            -> [renderForm (st^.csNotifyPrefs.singular _Just)]

--- a/src/Draw/NotifyPrefs.hs
+++ b/src/Draw/NotifyPrefs.hs
@@ -6,7 +6,6 @@ where
 import Prelude ()
 import Prelude.MH
 
-import Data.Maybe (fromJust)
 import Brick
 import Brick.Widgets.Border
 import Brick.Widgets.Center
@@ -16,9 +15,10 @@ import Types
 
 drawNotifyPrefs :: ChatState -> Widget Name
 drawNotifyPrefs st =
-    let form = fromJust $ st^.csNotifyPrefs
+    let Just form = st^.csNotifyPrefs
+        label = str "Notification Preferences"
     in centerLayer $
        vLimit 20 $
        hLimit 60 $
-       border $
+       borderWithLabel label $
        renderForm form

--- a/src/Draw/NotifyPrefs.hs
+++ b/src/Draw/NotifyPrefs.hs
@@ -1,0 +1,24 @@
+module Draw.NotifyPrefs
+  ( drawNotifyPrefs
+  )
+where
+
+import Prelude ()
+import Prelude.MH
+
+import Data.Maybe (fromJust)
+import Brick
+import Brick.Widgets.Border
+import Brick.Widgets.Center
+import Brick.Forms (renderForm)
+
+import Types
+
+drawNotifyPrefs :: ChatState -> Widget Name
+drawNotifyPrefs st =
+    let form = fromJust $ st^.csNotifyPrefs
+    in centerLayer $
+       vLimit 20 $
+       hLimit 60 $
+       border $
+       renderForm form

--- a/src/Draw/NotifyPrefs.hs
+++ b/src/Draw/NotifyPrefs.hs
@@ -12,13 +12,15 @@ import Brick.Widgets.Center
 import Brick.Forms (renderForm)
 
 import Types
+import Themes
 
 drawNotifyPrefs :: ChatState -> Widget Name
 drawNotifyPrefs st =
     let Just form = st^.csNotifyPrefs
-        label = str "Notification Preferences"
+        label = forceAttr clientEmphAttr $ str "Notification Preferences"
     in centerLayer $
        vLimit 20 $
        hLimit 60 $
        borderWithLabel label $
+       padAll 1 $
        renderForm form

--- a/src/Draw/NotifyPrefs.hs
+++ b/src/Draw/NotifyPrefs.hs
@@ -10,17 +10,26 @@ import Brick
 import Brick.Widgets.Border
 import Brick.Widgets.Center
 import Brick.Forms (renderForm)
+import Data.List (intersperse)
 
+import Draw.Util (renderKeybindingHelp)
 import Types
+import Types.KeyEvents
 import Themes
 
 drawNotifyPrefs :: ChatState -> Widget Name
 drawNotifyPrefs st =
     let Just form = st^.csNotifyPrefs
         label = forceAttr clientEmphAttr $ str "Notification Preferences"
+        formKeys = withDefAttr clientEmphAttr <$> txt <$> ["Tab", "BackTab"]
+        bindings = vBox $ hCenter <$> [ renderKeybindingHelp "Save" [FormSubmitEvent] <+> txt "  " <+>
+                                        renderKeybindingHelp "Cancel" [CancelEvent]
+                                      , hBox ((intersperse (txt "/") formKeys) <> [txt (":Cycle form fields")])
+                                      , hBox [withDefAttr clientEmphAttr $ txt "Space", txt ":Toggle form field"]
+                                      ]
     in centerLayer $
-       vLimit 20 $
-       hLimit 60 $
+       vLimit 25 $
+       hLimit 39 $
+       joinBorders $
        borderWithLabel label $
-       padAll 1 $
-       renderForm form
+       (padAll 1 $ renderForm form) <=> hBorder <=> bindings

--- a/src/Draw/TabbedWindow.hs
+++ b/src/Draw/TabbedWindow.hs
@@ -12,10 +12,10 @@ import           Brick.Widgets.Center
 import           Data.List ( intersperse )
 import qualified Graphics.Vty as Vty
 
+import           Draw.Util ( renderKeybindingHelp )
 import           Types
 import           Themes
 import           Types.KeyEvents
-import           Events.Keybindings ( getFirstDefaultBinding )
 
 -- | Render a tabbed window.
 drawTabbedWindow :: (Eq a, Show a)
@@ -36,12 +36,10 @@ drawTabbedWindow w cs =
 -- | Keybinding help to show at the bottom of a tabbed window.
 keybindingHelp :: Widget Name
 keybindingHelp =
-    let ppPair (label, evs) = hBox $ (intersperse (txt "/") $ ppEv <$> evs) <> [txt (":" <> label)]
-        ppEv ev = withDefAttr clientEmphAttr $ txt (ppBinding (getFirstDefaultBinding ev))
-        pairs = [ ("Switch tabs", [SelectNextTabEvent, SelectPreviousTabEvent])
+    let pairs = [ ("Switch tabs", [SelectNextTabEvent, SelectPreviousTabEvent])
                 , ("Scroll", [ScrollUpEvent, ScrollDownEvent, ScrollLeftEvent, ScrollRightEvent, PageLeftEvent, PageRightEvent])
                 ]
-    in hBox $ intersperse (txt "  ") $ ppPair <$> pairs
+    in hBox $ intersperse (txt "  ") $ (uncurry renderKeybindingHelp) <$> pairs
 
 -- | The scrollable tab bar to show at the top of a tabbed window.
 tabBar :: (Eq a, Show a)

--- a/src/Draw/Util.hs
+++ b/src/Draw/Util.hs
@@ -2,6 +2,7 @@ module Draw.Util
   ( withBrackets
   , renderTime
   , renderDate
+  , renderKeybindingHelp
   , insertDateMarkers
   , getDateFormat
   , mkChannelName
@@ -14,6 +15,7 @@ import           Prelude ()
 import           Prelude.MH
 
 import           Brick
+import           Data.List ( intersperse )
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import           Lens.Micro.Platform ( to )
@@ -22,6 +24,8 @@ import           Network.Mattermost.Types
 import           Themes
 import           TimeUtils
 import           Types
+import           Types.KeyEvents
+import           Events.Keybindings ( getFirstDefaultBinding )
 
 
 defaultTimeFormat :: Text
@@ -52,6 +56,11 @@ renderUTCTime fmt tz t =
     if T.null fmt
     then emptyWidget
     else withDefAttr timeAttr (txt $ localTimeText fmt $ asLocalTime tz t)
+
+renderKeybindingHelp :: Text -> [KeyEvent] -> Widget Name
+renderKeybindingHelp label evs =
+  let ppEv ev = withDefAttr clientEmphAttr $ txt (ppBinding (getFirstDefaultBinding ev))
+  in hBox $ (intersperse (txt "/") $ ppEv <$> evs) <> [txt (":" <> label)]
 
 -- | Generates a local matterhorn-only client message that creates a
 -- date marker.  The server date is converted to a local time (via

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -200,6 +200,7 @@ handleGlobalEvent e = do
         ViewMessage                -> void $ handleTabbedWindowEvent (csViewedMessage.singular _Just._2) e
         ManageAttachments          -> onEventManageAttachments e
         ManageAttachmentsBrowseFiles -> onEventManageAttachments e
+        EditNotifyPrefs            -> onEventMain e
 
 globalKeybindings :: KeyConfig -> KeyHandlerMap
 globalKeybindings = mkKeybindings globalKeyHandlers

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -48,6 +48,7 @@ import           Events.ChannelListOverlay
 import           Events.ReactionEmojiListOverlay
 import           Events.TabbedWindow
 import           Events.ManageAttachments
+import           Events.EditNotifyPrefs
 
 
 onEvent :: ChatState -> BrickEvent Name MHEvent -> EventM Name (Next ChatState)
@@ -200,7 +201,7 @@ handleGlobalEvent e = do
         ViewMessage                -> void $ handleTabbedWindowEvent (csViewedMessage.singular _Just._2) e
         ManageAttachments          -> onEventManageAttachments e
         ManageAttachmentsBrowseFiles -> onEventManageAttachments e
-        EditNotifyPrefs            -> onEventMain e
+        EditNotifyPrefs            -> void $ onEventEditNotifyPrefs e
 
 globalKeybindings :: KeyConfig -> KeyHandlerMap
 globalKeybindings = mkKeybindings globalKeyHandlers

--- a/src/Events/EditNotifyPrefs.hs
+++ b/src/Events/EditNotifyPrefs.hs
@@ -36,14 +36,13 @@ editNotifyPrefsKeybindings = mkKeybindings editNotifyPrefsKeyHandlers
 editNotifyPrefsKeyHandlers :: [KeyEventHandler]
 editNotifyPrefsKeyHandlers =
     [ mkKb CancelEvent "Close channel notification preferences" exitEditNotifyPrefsMode
-    , staticKb "Save channel notification preferences"
-        (V.EvKey V.KEnter []) $ do
-            st <- use id
-            let form = fromJust $ st^.csNotifyPrefs
-                cId = st^.csCurrentChannelId
+    , mkKb FormSubmitEvent "Save channel notification preferences" $ do
+        st <- use id
+        let form = fromJust $ st^.csNotifyPrefs
+            cId = st^.csCurrentChannelId
 
-            doAsyncChannelMM Preempt cId
-                (\s _ -> MM.mmUpdateChannelNotifications cId (myUserId st) (formState form) s)
-                (\_ _ -> Nothing)
-            exitEditNotifyPrefsMode
+        doAsyncChannelMM Preempt cId
+          (\s _ -> MM.mmUpdateChannelNotifications cId (myUserId st) (formState form) s)
+          (\_ _ -> Nothing)
+        exitEditNotifyPrefsMode
     ]

--- a/src/Events/EditNotifyPrefs.hs
+++ b/src/Events/EditNotifyPrefs.hs
@@ -1,0 +1,35 @@
+module Events.EditNotifyPrefs
+    ( onEventEditNotifyPrefs
+    , editNotifyPrefsKeybindings
+    , editNotifyPrefsKeyHandlers
+    )
+where
+
+import           Prelude ()
+import           Prelude.MH
+
+import           Brick
+import           Brick.Forms (handleFormEvent)
+import qualified Graphics.Vty as V
+
+import           Lens.Micro.Platform (_Just, (.=), singular)
+
+import           Types
+import           Types.KeyEvents
+import           Events.Keybindings
+import           State.NotifyPrefs
+
+onEventEditNotifyPrefs :: V.Event -> MH Bool
+onEventEditNotifyPrefs =
+    let fallback e = do
+            form <- use (csNotifyPrefs.singular _Just)
+            updatedForm <- mh $ handleFormEvent (VtyEvent e) form
+            csNotifyPrefs .= Just updatedForm
+    in handleKeyboardEvent editNotifyPrefsKeybindings fallback
+
+editNotifyPrefsKeybindings :: KeyConfig -> KeyHandlerMap
+editNotifyPrefsKeybindings = mkKeybindings editNotifyPrefsKeyHandlers
+
+editNotifyPrefsKeyHandlers :: [KeyEventHandler]
+editNotifyPrefsKeyHandlers =
+    [ mkKb CancelEvent "Close channel notification preferences" exitEditNotifyPrefsMode ]

--- a/src/Events/Keybindings.hs
+++ b/src/Events/Keybindings.hs
@@ -224,6 +224,7 @@ defaultBindings ev =
         EditorHomeEvent               -> [ kb Vty.KHome ]
         EditorEndEvent                -> [ kb Vty.KEnd ]
         EditorYankEvent               -> [ ctrl (key 'y') ]
+        FormSubmitEvent               -> [ kb Vty.KEnter ]
 
 -- | Given a configuration, we want to check it for internal consistency
 -- (i.e. that a given keybinding isn't associated with multiple events

--- a/src/State/NotifyPrefs.hs
+++ b/src/State/NotifyPrefs.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+module State.NotifyPrefs
+    ( enterEditNotifyPrefsMode
+    )
+where
+
+import Prelude ()
+import Prelude.MH
+
+import Types
+import Types.Channels ( channelNotifyPropsMarkUnreadL
+                      , channelNotifyPropsIgnoreChannelMentionsL
+                      , channelNotifyPropsDesktopL
+                      , channelNotifyPropsPushL
+                      )
+
+import Network.Mattermost.Types ( ChannelNotifyProps
+                                , channelNotifyPropsMarkUnread
+                                , channelNotifyPropsIgnoreChannelMentions
+                                , WithDefault(..)
+                                , NotifyOption(..)
+                                )
+
+import Brick
+import Brick.Forms
+import Lens.Micro.Platform ( Lens', (.=), lens )
+
+muteLens :: Lens' ChannelNotifyProps Bool
+muteLens = lens (\props -> props^.channelNotifyPropsMarkUnreadL == IsValue NotifyOptionMention)
+           (\props muted -> props { channelNotifyPropsMarkUnread =
+                                          if muted
+                                          then IsValue NotifyOptionMention
+                                          else IsValue NotifyOptionAll
+                                  })
+
+channelMentionLens :: Lens' ChannelNotifyProps Bool
+channelMentionLens = lens (\props -> (props^.channelNotifyPropsIgnoreChannelMentionsL) == (IsValue True))
+                     (\props ignoreChannelMentions ->
+                          props { channelNotifyPropsIgnoreChannelMentions = if ignoreChannelMentions
+                                                                            then IsValue True
+                                                                            else Default
+                                })
+
+mkNotifyButtons :: ((WithDefault NotifyOption) -> Name)
+                -> Lens' ChannelNotifyProps (WithDefault NotifyOption)
+                -> ChannelNotifyProps
+                -> FormFieldState ChannelNotifyProps e Name
+mkNotifyButtons mkName l =
+    radioField l [ (Default, mkName Default, "Global default")
+                 , (IsValue NotifyOptionAll, mkName $ IsValue NotifyOptionAll, "All activity")
+                 , (IsValue NotifyOptionMention, mkName $ IsValue NotifyOptionMention, "Mentions")
+                 , (IsValue NotifyOptionNone, mkName $ IsValue NotifyOptionNone, "Never")
+                 ]
+    
+notifyPrefsForm :: ChannelNotifyProps -> Form ChannelNotifyProps e Name
+notifyPrefsForm =
+    newForm [ checkboxField muteLens MuteToggleField "Mute channel"
+            , checkboxField channelMentionLens ChannelMentionsField "Ignore channel mentions"
+            , (str "Desktop notifications" <=>) . (padLeft $ Pad 1) @@=
+                mkNotifyButtons DesktopNotificationsField channelNotifyPropsDesktopL
+            , (str "Push notifications" <=>) . (padLeft $ Pad 1) @@=
+                mkNotifyButtons PushNotificationsField channelNotifyPropsPushL
+            ]

--- a/src/State/NotifyPrefs.hs
+++ b/src/State/NotifyPrefs.hs
@@ -19,6 +19,7 @@ import Types.Channels ( channelNotifyPropsMarkUnreadL
 import Network.Mattermost.Types ( ChannelNotifyProps
                                 , User(..)
                                 , UserNotifyProps(..)
+                                , Type(..)
                                 , channelNotifyPropsMarkUnread
                                 , channelNotifyPropsIgnoreChannelMentions
                                 , WithDefault(..)
@@ -77,10 +78,14 @@ notifyPrefsForm globalDefaults =
 
 enterEditNotifyPrefsMode :: MH ()
 enterEditNotifyPrefsMode = do
-    props <- use (csCurrentChannel.ccInfo.cdNotifyProps)
-    user <- use csMe
-    csNotifyPrefs .= (Just (notifyPrefsForm (userNotifyProps user) props))
-    setMode EditNotifyPrefs
+    chanInfo <- use (csCurrentChannel.ccInfo)
+    case chanInfo^.cdType of
+      Direct -> mhError $ GenericError "Cannot open notification preferences for DM channel."
+      _ -> do
+        let props = chanInfo^.cdNotifyProps
+        user <- use csMe
+        csNotifyPrefs .= (Just (notifyPrefsForm (userNotifyProps user) props))
+        setMode EditNotifyPrefs
 
 exitEditNotifyPrefsMode :: MH ()
 exitEditNotifyPrefsMode = do

--- a/src/State/NotifyPrefs.hs
+++ b/src/State/NotifyPrefs.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 module State.NotifyPrefs
     ( enterEditNotifyPrefsMode
+    , exitEditNotifyPrefsMode
     )
 where
 
@@ -52,7 +53,7 @@ mkNotifyButtons mkName l =
                  , (IsValue NotifyOptionMention, mkName $ IsValue NotifyOptionMention, "Mentions")
                  , (IsValue NotifyOptionNone, mkName $ IsValue NotifyOptionNone, "Never")
                  ]
-    
+
 notifyPrefsForm :: ChannelNotifyProps -> Form ChannelNotifyProps e Name
 notifyPrefsForm =
     newForm [ checkboxField muteLens MuteToggleField "Mute channel"
@@ -62,3 +63,13 @@ notifyPrefsForm =
             , (str "Push notifications" <=>) . (padLeft $ Pad 1) @@=
                 mkNotifyButtons PushNotificationsField channelNotifyPropsPushL
             ]
+
+enterEditNotifyPrefsMode :: MH ()
+enterEditNotifyPrefsMode = do
+    props <- use (csCurrentChannel.ccInfo.cdNotifyProps)
+    csNotifyPrefs .= Just (notifyPrefsForm props)
+    setMode EditNotifyPrefs
+
+exitEditNotifyPrefsMode :: MH ()
+exitEditNotifyPrefsMode = do
+    setMode Main

--- a/src/State/NotifyPrefs.hs
+++ b/src/State/NotifyPrefs.hs
@@ -57,12 +57,13 @@ mkNotifyButtons mkName l =
 notifyPrefsForm :: ChannelNotifyProps -> Form ChannelNotifyProps e Name
 notifyPrefsForm =
     newForm [ checkboxField muteLens MuteToggleField "Mute channel"
-            , checkboxField channelMentionLens ChannelMentionsField "Ignore channel mentions"
-            , (str "Desktop notifications" <=>) . (padLeft $ Pad 1) @@=
+            , (padTop $ Pad 1) @@= checkboxField channelMentionLens ChannelMentionsField "Ignore channel mentions"
+            , radioStyle "Desktop notifications" @@=
                 mkNotifyButtons DesktopNotificationsField channelNotifyPropsDesktopL
-            , (str "Push notifications" <=>) . (padLeft $ Pad 1) @@=
+            , radioStyle "Push notifications" @@=
                 mkNotifyButtons PushNotificationsField channelNotifyPropsPushL
             ]
+    where radioStyle label = (padTop $ Pad 1 ) . (str label <=>) . (padLeft $ Pad 1)
 
 enterEditNotifyPrefsMode :: MH ()
 enterEditNotifyPrefsMode = do

--- a/src/State/NotifyPrefs.hs
+++ b/src/State/NotifyPrefs.hs
@@ -36,7 +36,7 @@ muteLens = lens (\props -> props^.channelNotifyPropsMarkUnreadL == IsValue Notif
                                   })
 
 channelMentionLens :: Lens' ChannelNotifyProps Bool
-channelMentionLens = lens (\props -> (props^.channelNotifyPropsIgnoreChannelMentionsL) == (IsValue True))
+channelMentionLens = lens (\props -> props^.channelNotifyPropsIgnoreChannelMentionsL == IsValue True)
                      (\props ignoreChannelMentions ->
                           props { channelNotifyPropsIgnoreChannelMentions = if ignoreChannelMentions
                                                                             then IsValue True

--- a/src/Themes.hs
+++ b/src/Themes.hs
@@ -68,6 +68,7 @@ import           Brick.Widgets.Skylighting ( attrNameForTokenType
                                            , attrMappingsForStyle
                                            , highlightedCodeBlockAttr
                                            )
+import           Brick.Forms ( focusedFormInputAttr )
 import           Data.Hashable ( hash )
 import qualified Data.Map as M
 import qualified Data.Text as T
@@ -287,6 +288,7 @@ lightAttrs usernameColors =
        , (editedMarkingAttr,                fg yellow)
        , (editedRecentlyMarkingAttr,        black `on` yellow)
        , (tabSelectedAttr,                  black `on` yellow)
+       , (focusedFormInputAttr,             black `on` yellow)
        , (FB.fileBrowserCurrentDirectoryAttr, white `on` blue)
        , (FB.fileBrowserSelectionInfoAttr,  white `on` blue)
        , (FB.fileBrowserDirectoryAttr,      fg blue)
@@ -342,6 +344,7 @@ darkAttrs usernameColors =
      , (editedMarkingAttr,                fg yellow)
      , (editedRecentlyMarkingAttr,        black `on` yellow)
      , (tabSelectedAttr,                  black `on` yellow)
+     , (focusedFormInputAttr,             black `on` yellow)
      , (FB.fileBrowserCurrentDirectoryAttr, white `on` blue)
      , (FB.fileBrowserSelectionInfoAttr,  white `on` blue)
      , (FB.fileBrowserDirectoryAttr,      fg blue)
@@ -727,6 +730,9 @@ themeDocs = ThemeDocumentation $ M.fromList $
       )
     , ( listSelectedFocusedAttr
       , "The selected channel"
+      )
+    , ( focusedFormInputAttr
+      , "A form input that has focus"
       )
     , ( FB.fileBrowserAttr
       , "The base file browser attribute"

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -101,6 +101,7 @@ module Types
   , csClientConfig
   , csPendingChannelChange
   , csViewedMessage
+  , csNotifyPrefs
   , timeZone
   , whenMode
   , setMode
@@ -281,6 +282,7 @@ import           Brick.Themes ( Theme )
 import           Brick.Main ( invalidateCache, invalidateCacheEntry )
 import           Brick.AttrMap ( AttrMap )
 import qualified Brick.BChan as BCH
+import           Brick.Forms (Form)
 import           Brick.Widgets.Edit ( Editor, editor )
 import           Brick.Widgets.List ( List, list )
 import qualified Brick.Widgets.FileBrowser as FB
@@ -670,6 +672,10 @@ data Name =
     | ReactionEmojiList
     | ReactionEmojiListInput
     | TabbedWindowTabBar
+    | MuteToggleField
+    | ChannelMentionsField
+    | DesktopNotificationsField (WithDefault NotifyOption)
+    | PushNotificationsField (WithDefault NotifyOption)
     deriving (Eq, Show, Ord)
 
 -- | The sum type of exceptions we expect to encounter on authentication
@@ -1085,6 +1091,7 @@ data Mode =
     | ViewMessage
     | ManageAttachments
     | ManageAttachmentsBrowseFiles
+    | EditNotifyPrefs
     deriving (Eq)
 
 -- | We're either connected or we're not.
@@ -1341,6 +1348,7 @@ data ChatState =
               -- consult the chat state for the latest *version* of any
               -- message with an ID here, to be sure that the latest
               -- version is used (e.g. if it gets edited, etc.).
+              , _csNotifyPrefs :: Maybe (Form ChannelNotifyProps MHEvent Name)
               }
 
 -- | Handles for the View Message window's tabs.
@@ -1398,6 +1406,7 @@ newState (StartupStateInfo {..}) = do
                      , _csClientConfig                = Nothing
                      , _csPendingChannelChange        = Nothing
                      , _csViewedMessage               = Nothing
+                     , _csNotifyPrefs                 = Nothing
                      }
 
 nullChannelListOverlayState :: ListOverlayState Channel ChannelSearchScope

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1350,6 +1350,10 @@ data ChatState =
               -- message with an ID here, to be sure that the latest
               -- version is used (e.g. if it gets edited, etc.).
               , _csNotifyPrefs :: Maybe (Form ChannelNotifyProps MHEvent Name)
+              -- ^ A form for editing the notification preferences for
+              -- the current channel. This is set when entering
+              -- EditNotifyPrefs mode and updated when the user
+              -- changes the form state.
               }
 
 -- | Handles for the View Message window's tabs.

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -102,6 +102,7 @@ module Types
   , csPendingChannelChange
   , csViewedMessage
   , csNotifyPrefs
+  , csMe
   , timeZone
   , whenMode
   , setMode

--- a/src/Types/Channels.hs
+++ b/src/Types/Channels.hs
@@ -42,6 +42,10 @@ module Types.Channels
   -- * Notification settings
   , notifyPreference
   , isMuted
+  , channelNotifyPropsMarkUnreadL
+  , channelNotifyPropsIgnoreChannelMentionsL
+  , channelNotifyPropsDesktopL
+  , channelNotifyPropsPushL
   -- * Miscellaneous channel-related operations
   , canLeaveChannel
   , preferredChannelName

--- a/src/Types/KeyEvents.hs
+++ b/src/Types/KeyEvents.hs
@@ -121,6 +121,9 @@ data KeyEvent
   | AttachmentListAddEvent
   | AttachmentListDeleteEvent
   | AttachmentOpenEvent
+
+  -- Form submission
+  | FormSubmitEvent
     deriving (Eq, Show, Ord, Enum)
 
 allEvents :: [KeyEvent]
@@ -206,6 +209,7 @@ allEvents =
   , AttachmentListAddEvent
   , AttachmentListDeleteEvent
   , AttachmentOpenEvent
+  , FormSubmitEvent
   ]
 
 eventToBinding :: Vty.Event -> Binding
@@ -426,3 +430,5 @@ keyEventName ev = case ev of
   AttachmentListAddEvent    -> "add-to-attachment-list"
   AttachmentListDeleteEvent -> "delete-from-attachment-list"
   AttachmentOpenEvent       -> "open-attachment"
+
+  FormSubmitEvent -> "submit-form"


### PR DESCRIPTION
This PR adds a command `/notify-prefs` which allows the user to change the notification preferences for the current channel. A few notes:

- This does not allow the user to change the global notification preferences.

- Matterhorn only checks to see if the user is attempting to save or cancel and passes all other keypresses to `handleFormEvent`. This means that the keys for changing the form state cannot be rebound. If we want to make them rebindable, I guess I could have Matterhorn handle all the key events and update the form state directly.

- I only added the options which could be changed from the web client. The Mattermost API also has a per-channel setting for email notifications.

- Changing the notification preferences is disabled on individual DM channels, just like in the web client. You can still use `/mute` to mute a DM channel.