### PR TITLE
Use https urls for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "submodules/mattermost-api-qc"]
 	path = submodules/mattermost-api-qc
-	url = git@github.com:matterhorn-chat/mattermost-api-qc.git
+	url = https://github.com/matterhorn-chat/mattermost-api-qc.git
 [submodule "submodules/mattermost-api"]
 	path = submodules/mattermost-api
-	url = git@github.com:matterhorn-chat/mattermost-api.git
+	url = https://github.com/matterhorn-chat/mattermost-api.git


### PR DESCRIPTION
When building matterhorn behind a proxy, using git@ urls for submodules causes builds to fail. Using https urls for submodules fixes this. 