### PR TITLE
Support login with 2FA token

### DIFF
--- a/src/Matterhorn/Login.hs
+++ b/src/Matterhorn/Login.hs
@@ -449,8 +449,7 @@ mkOTPForm :: ConnectionInfo -> Form ConnectionInfo e Name
 mkOTPForm =
     let label s w = padBottom (Pad 1) $
                     (vLimit 1 $ hLimit 10 $ str s <+> fill ' ') <+> w
-        wrapMaybe func = fmap Just . func . (fromMaybe "")
-    in newForm [label "OTP Token:" @@= editTextField (ciOTPToken . wrapMaybe) OTPToken (Just 1)]
+    in newForm [label "OTP Token:" @@= editOptionalTextField ciOTPToken OTPToken]
 
 serverLens :: Lens' ConnectionInfo (Text, Int, Text, ConnectionType)
 serverLens f ci = fmap (\(x,y,z,w) -> ci { _ciHostname = x, _ciPort = y, _ciUrlPath = z, _ciType = w})
@@ -539,6 +538,18 @@ editServer =
         renderTxt [""] = str "(Paste your Mattermost URL here)"
         renderTxt ts = txt (T.unlines ts)
     in editField serverLens Server limit renderServer val renderTxt id
+
+editOptionalTextField :: (Show n, Ord n) => Lens' s (Maybe T.Text) -> n -> s -> FormFieldState s e n
+editOptionalTextField stLens n =
+    let ini Nothing = ""
+        ini (Just t) = t
+        val ls =
+            let stripped = T.strip $ T.concat ls
+            in if T.null stripped
+               then Just Nothing
+               else Just $ Just stripped
+        renderTxt ts = txt (T.unlines ts)
+    in editField stLens n (Just 1) ini val renderTxt id
 
 errorAttr :: AttrName
 errorAttr = "errorMessage"

--- a/src/Matterhorn/State/Setup.hs
+++ b/src/Matterhorn/State/Setup.hs
@@ -47,6 +47,7 @@ incompleteCredentials config = ConnectionInfo
   , _ciPassword = case configPass config of
                     Just (PasswordString s) -> s
                     _                       -> ""
+  , _ciToken = ""
   , _ciAccessToken = case configToken config of
                        Just (TokenString s) -> s
                        _                    -> ""

--- a/src/Matterhorn/State/Setup.hs
+++ b/src/Matterhorn/State/Setup.hs
@@ -47,7 +47,7 @@ incompleteCredentials config = ConnectionInfo
   , _ciPassword = case configPass config of
                     Just (PasswordString s) -> s
                     _                       -> ""
-  , _ciToken = ""
+  , _ciOTPToken = Nothing
   , _ciAccessToken = case configToken config of
                        Just (TokenString s) -> s
                        _                    -> ""
@@ -80,7 +80,7 @@ setupState mkVty mLogLocation config = do
   let logApiEvent ev = apiLogEventToLogMessage ev >>= sendLogMessage logMgr
       setLogger cd = cd `withLogger` logApiEvent
 
-  (mLoginData, loginVty) <- interactiveGetLoginSession initialVty mkVty
+  (mLoginSuccess, loginVty) <- interactiveGetLoginSession initialVty mkVty
                                                        setLogger
                                                        logMgr
                                                        (incompleteCredentials config)
@@ -89,7 +89,7 @@ setupState mkVty mLogLocation config = do
           Vty.shutdown vty
           exitSuccess
 
-  (session, me, cd, mbTeam) <- case mLoginData of
+  (session, me, cd, mbTeam) <- case mLoginSuccess of
       Nothing ->
           -- The user never attempted a connection and just chose to
           -- quit.

--- a/src/Matterhorn/State/Setup.hs
+++ b/src/Matterhorn/State/Setup.hs
@@ -80,25 +80,21 @@ setupState mkVty mLogLocation config = do
   let logApiEvent ev = apiLogEventToLogMessage ev >>= sendLogMessage logMgr
       setLogger cd = cd `withLogger` logApiEvent
 
-  (mLastAttempt, loginVty) <- interactiveGetLoginSession initialVty mkVty
-                                                         setLogger
-                                                         logMgr
-                                                         (incompleteCredentials config)
+  (mLoginData, loginVty) <- interactiveGetLoginSession initialVty mkVty
+                                                       setLogger
+                                                       logMgr
+                                                       (incompleteCredentials config)
 
   let shutdown vty = do
           Vty.shutdown vty
           exitSuccess
 
-  (session, me, cd, mbTeam) <- case mLastAttempt of
+  (session, me, cd, mbTeam) <- case mLoginData of
       Nothing ->
           -- The user never attempted a connection and just chose to
           -- quit.
           shutdown loginVty
-      Just (AttemptFailed {}) ->
-          -- The user attempted a connection and failed, and then chose
-          -- to quit.
-          shutdown loginVty
-      Just (AttemptSucceeded _ cd sess user mbTeam) ->
+      Just (LoginSuccess cd sess user mbTeam) ->
           -- The user attempted a connection and succeeded so continue
           -- with setup.
           return (sess, user, cd, mbTeam)

--- a/src/Matterhorn/Types.hs
+++ b/src/Matterhorn/Types.hs
@@ -46,7 +46,7 @@ module Matterhorn.Types
   , ciPort
   , ciUrlPath
   , ciUsername
-  , ciToken
+  , ciOTPToken
   , ciPassword
   , ciType
   , ciAccessToken
@@ -934,7 +934,7 @@ data ConnectionInfo =
                    , _ciPort     :: Int
                    , _ciUrlPath  :: Text
                    , _ciUsername :: Text
-                   , _ciToken    :: Text
+                   , _ciOTPToken :: Maybe Text
                    , _ciPassword :: Text
                    , _ciAccessToken :: Text
                    , _ciType     :: ConnectionType

--- a/src/Matterhorn/Types.hs
+++ b/src/Matterhorn/Types.hs
@@ -46,6 +46,7 @@ module Matterhorn.Types
   , ciPort
   , ciUrlPath
   , ciUsername
+  , ciToken
   , ciPassword
   , ciType
   , ciAccessToken
@@ -933,6 +934,7 @@ data ConnectionInfo =
                    , _ciPort     :: Int
                    , _ciUrlPath  :: Text
                    , _ciUsername :: Text
+                   , _ciToken    :: Text
                    , _ciPassword :: Text
                    , _ciAccessToken :: Text
                    , _ciType     :: ConnectionType


### PR DESCRIPTION
**I don't think this should be merged as it is**.

So I've hacked together this code, to keep using matterhorn. This is how login form looks after my changes:

![ss](https://user-images.githubusercontent.com/7026881/92124471-1e0f0b80-edfe-11ea-93c7-7fa4176e2dd6.png)

This works for me, but is ugly when user *don't* need 2FA token to login.

I'm open for improving this PR, but looking for feedback first.

See also my post at #228.

Note: this depends on https://github.com/matterhorn-chat/mattermost-api/pull/56.