### PR TITLE
Add /attach command

### DIFF
--- a/src/Matterhorn/Command.hs
+++ b/src/Matterhorn/Command.hs
@@ -21,6 +21,7 @@ import qualified Network.Mattermost.Endpoints as MM
 import qualified Network.Mattermost.Exceptions as MM
 import qualified Network.Mattermost.Types as MM
 
+import           Matterhorn.State.Attachments
 import           Matterhorn.Connection ( connectWebsockets )
 import           Matterhorn.Constants ( userSigil, normalChannelSigil )
 import           Matterhorn.HelpTopics
@@ -276,6 +277,9 @@ commandList =
 
   , Cmd "move-team-right" "Move the currently-selected team to the right in the team list" NoArg $ \_ ->
         moveCurrentTeamRight
+
+  , Cmd "attach" "Attach a given file without browsing" (LineArg "path") $
+        attachFileByPath
   ]
 
 displayUsernameAttribute :: Text -> MH ()

--- a/src/Matterhorn/Events.hs
+++ b/src/Matterhorn/Events.hs
@@ -157,9 +157,9 @@ formatError (NoSuchHelpTopic topic) =
     let knownTopics = ("  - " <>) <$> helpTopicName <$> helpTopics
     in "Unknown help topic: `" <> topic <> "`. " <>
        (T.unlines $ "Available topics are:" : knownTopics)
-formatError (BadAttachmentPath e) =
+formatError (AttachmentException e) =
     case fromException e of
-      Just (ioe :: IO.IOError) -> 
+      Just (ioe :: IO.IOError) ->
           if IO.isDoesNotExistError ioe
           then "Error attaching, file does not exist!"
           else if IO.isPermissionError ioe
@@ -168,6 +168,8 @@ formatError (BadAttachmentPath e) =
       Nothing -> "Unknown error attaching file!\n" <>
           "Please report this error at https://github.com/matterhorn-chat/matterhorn/issues"
           -- this case shouldn't be reached
+formatError (BadAttachmentPath msg) = 
+    msg
 formatError (AsyncErrEvent e) =
     "An unexpected error has occurred! The exception encountered was:\n  " <>
     T.pack (show e) <>

--- a/src/Matterhorn/Events.hs
+++ b/src/Matterhorn/Events.hs
@@ -155,6 +155,8 @@ formatError (NoSuchHelpTopic topic) =
     let knownTopics = ("  - " <>) <$> helpTopicName <$> helpTopics
     in "Unknown help topic: `" <> topic <> "`. " <>
        (T.unlines $ "Available topics are:" : knownTopics)
+formatError (BadFile file) =
+    "Specified file " <> file <> " either doesn't exist or couldn't be read"
 formatError (AsyncErrEvent e) =
     "An unexpected error has occurred! The exception encountered was:\n  " <>
     T.pack (show e) <>

--- a/src/Matterhorn/Events.hs
+++ b/src/Matterhorn/Events.hs
@@ -10,6 +10,7 @@ import           Matterhorn.Prelude
 
 import           Brick
 import qualified Data.Text as T
+import           GHC.Exception.Type ( displayException )
 import qualified Graphics.Vty as Vty
 import           Lens.Micro.Platform ( (.=), _2, singular, _Just )
 
@@ -155,8 +156,8 @@ formatError (NoSuchHelpTopic topic) =
     let knownTopics = ("  - " <>) <$> helpTopicName <$> helpTopics
     in "Unknown help topic: `" <> topic <> "`. " <>
        (T.unlines $ "Available topics are:" : knownTopics)
-formatError (BadFile file) =
-    "Specified file " <> file <> " either doesn't exist or couldn't be read"
+formatError (BadAttachmentPath e msg) =
+    msg <> " The exception encountered was:\n " <> T.pack (displayException e)
 formatError (AsyncErrEvent e) =
     "An unexpected error has occurred! The exception encountered was:\n  " <>
     T.pack (show e) <>

--- a/src/Matterhorn/Events/ManageAttachments.hs
+++ b/src/Matterhorn/Events/ManageAttachments.hs
@@ -12,10 +12,8 @@ where
 import           Prelude ()
 import           Matterhorn.Prelude
 
-import qualified Control.Exception as E
 import qualified Brick.Widgets.FileBrowser as FB
 import qualified Brick.Widgets.List as L
-import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Data.Vector as Vector
 import qualified Graphics.Vty as V
@@ -127,38 +125,11 @@ cancelAttachmentBrowse = do
 
 handleFileBrowserEvent :: V.Event -> MH ()
 handleFileBrowserEvent e = do
-  let fbHandle ev = sequence . (fmap (FB.handleFileBrowserEvent ev))
-  mhHandleEventLensed (csCurrentTeam.tsEditState.cedFileBrowser) fbHandle e
-
-  withFileBrowser $ \b -> do
+    let fbHandle ev = sequence . (fmap (FB.handleFileBrowserEvent ev))
+    mhHandleEventLensed (csCurrentTeam.tsEditState.cedFileBrowser) fbHandle e
     -- TODO: Check file browser exception state
-    let entries = FB.fileBrowserSelection b
-    forM_ entries $ \entry -> do
-        -- Is the entry already present? If so, ignore the selection.
-        es <- use (csCurrentTeam.tsEditState.cedAttachmentList.L.listElementsL)
-        let matches = (== (FB.fileInfoFilePath entry)) .
-                      FB.fileInfoFilePath .
-                      attachmentDataFileInfo
-        case Vector.find matches es of
-            Just _ -> return ()
-            Nothing -> do
-                let path = FB.fileInfoFilePath entry
-                readResult <- liftIO $ E.try $ BS.readFile path
-                case readResult of
-                    Left (_::E.SomeException) ->
-                        -- TODO: report the error
-                        return ()
-                    Right bytes -> do
-                        let a = AttachmentData { attachmentDataFileInfo = entry
-                                               , attachmentDataBytes = bytes
-                                               }
-                        oldIdx <- use (csCurrentTeam.tsEditState.cedAttachmentList.L.listSelectedL)
-                        let newIdx = if Vector.null es
-                                     then Just 0
-                                     else oldIdx
-                        csCurrentTeam.tsEditState.cedAttachmentList %= L.listReplace (Vector.snoc es a) newIdx
-
-    when (not $ null entries) $ setMode Main
+    withFileBrowser $ \b ->
+        tryAddAttachment $ FB.fileBrowserSelection b
 
 deleteSelectedAttachment :: MH ()
 deleteSelectedAttachment = do

--- a/src/Matterhorn/State/Attachments.hs
+++ b/src/Matterhorn/State/Attachments.hs
@@ -1,21 +1,29 @@
+{-# LANGUAGE LambdaCase #-}
 module Matterhorn.State.Attachments
   ( showAttachmentList
   , resetAttachmentList
   , showAttachmentFileBrowser
+  , attachFileByPath
+  , tryAddAttachment
+  , tryReadAttachment
   )
 where
 
 import           Prelude ()
 import           Matterhorn.Prelude
-import qualified Control.Exception as E
-import           Data.Either ( isRight )
-import           System.Directory ( doesDirectoryExist, getDirectoryContents )
-import           Data.Bool ( bool )
 
 import           Brick ( vScrollToBeginning, viewportScroll )
 import qualified Brick.Widgets.List as L
 import qualified Brick.Widgets.FileBrowser as FB
-import           Lens.Micro.Platform ( (.=) )
+import qualified Control.Exception as E
+import qualified Control.Monad.State as St
+import           Data.Bool ( bool )
+import qualified Data.ByteString as BS
+import           Data.Either ( isRight )
+import           Data.Text ( pack, unpack )
+import qualified Data.Vector as Vector
+import           Lens.Micro.Platform ( (.=), (%=) )
+import           System.Directory ( doesDirectoryExist, getDirectoryContents )
 
 import           Matterhorn.Types
 
@@ -54,3 +62,50 @@ showAttachmentFileBrowser = do
     browser <- liftIO $ Just <$> FB.newFileBrowser FB.selectNonDirectories (AttachmentFileBrowser tId) filePath
     csCurrentTeam.tsEditState.cedFileBrowser .= browser
     setMode ManageAttachmentsBrowseFiles
+
+attachFileByPath :: Text -> MH ()
+attachFileByPath txtPath = do
+    let strPath = unpack txtPath
+    fileInfo <- liftIO $ FB.getFileInfo strPath strPath
+    case FB.fileInfoFileStatus fileInfo of
+        Left _ -> do
+            mhLog LogError $ "Failed to obtain FileInfo for file: " <> txtPath
+            mhError $ BadFile txtPath
+        Right _ -> tryAddAttachment [fileInfo]
+
+tryAddAttachment :: [FB.FileInfo] -> MH ()
+tryAddAttachment entries = do
+    forM_ entries $ \entry -> do
+        -- Is the entry already present? If so, ignore the selection.
+        es <- use (csCurrentTeam.tsEditState.cedAttachmentList.L.listElementsL)
+        let matches = (== FB.fileInfoFilePath entry) .
+                          FB.fileInfoFilePath .
+                          attachmentDataFileInfo
+        case Vector.find matches es of
+            Just _ -> return ()
+            Nothing -> do
+                tryReadAttachment entry >>= \case
+                    Right a -> do
+                        oldIdx <- use (csCurrentTeam.tsEditState.cedAttachmentList.L.listSelectedL)
+                        let newIdx = if Vector.null es
+                                     then Just 0
+                                     else oldIdx
+                        csCurrentTeam.tsEditState.cedAttachmentList %= L.listReplace (Vector.snoc es a) newIdx
+                    Left (_::E.SomeException) -> do
+                        mhLog LogError $ pack $ "Failed reading file: " <> FB.fileInfoFilePath entry
+                        mhError $ BadFile $ pack $ FB.fileInfoFilePath entry
+
+    when (not $ null entries) $ setMode Main
+
+tryReadAttachment :: FB.FileInfo -> MH (Either E.SomeException AttachmentData)
+tryReadAttachment fi = do
+    let path = FB.fileInfoFilePath fi
+    mhLog LogError "Reading the bytes"
+    readResult <- liftIO $ E.try $ BS.readFile path
+    case readResult of
+        Right bytes -> do
+            return $ Right $
+                AttachmentData { attachmentDataFileInfo = fi
+                               , attachmentDataBytes = bytes
+                               }
+        Left e -> return $ Left e

--- a/src/Matterhorn/State/Attachments.hs
+++ b/src/Matterhorn/State/Attachments.hs
@@ -19,7 +19,7 @@ import qualified Control.Exception as E
 import           Data.Bool ( bool )
 import qualified Data.ByteString as BS
 import           Data.Either ( isRight )
-import           Data.Text ( pack, unpack )
+import           Data.Text ( unpack )
 import qualified Data.Vector as Vector
 import           GHC.Exception.Type ( toException )
 import           Lens.Micro.Platform ( (.=), (%=) )
@@ -69,7 +69,7 @@ attachFileByPath txtPath = do
     fileInfo <- liftIO $ FB.getFileInfo strPath strPath
     case FB.fileInfoFileStatus fileInfo of
         Left e -> do
-            mhError $ BadAttachmentPath (toException e) "Unable to stat the requested file.  Check that it exists and has proper permissions"
+            mhError $ BadAttachmentPath (toException e)
         Right _ -> tryAddAttachment [fileInfo]
 
 tryAddAttachment :: [FB.FileInfo] -> MH ()
@@ -90,15 +90,13 @@ tryAddAttachment entries = do
                                      then Just 0
                                      else oldIdx
                         csCurrentTeam.tsEditState.cedAttachmentList %= L.listReplace (Vector.snoc es a) newIdx
-                    Left e -> do
-                        mhError $ BadAttachmentPath e "Unable to read from the specified file."
+                    Left e -> mhError $ BadAttachmentPath e
 
     when (not $ null entries) $ setMode Main
 
 tryReadAttachment :: FB.FileInfo -> MH (Either E.SomeException AttachmentData)
 tryReadAttachment fi = do
     let path = FB.fileInfoFilePath fi
-    mhLog LogError "Reading the bytes"
     readResult <- liftIO $ E.try $ BS.readFile path
     case readResult of
         Right bytes -> do

--- a/src/Matterhorn/State/Editing.hs
+++ b/src/Matterhorn/State/Editing.hs
@@ -234,11 +234,14 @@ handleInputSubmission tId cId content = do
           mode <- use (csTeam(tId).tsEditState.cedEditMode)
           sendMessage cId mode content $ F.toList attachments
 
+          -- Empty the attachment list only if a mesage is actually sent, since
+          -- it's possible to /attach a file before actually sending the
+          -- message
+          resetAttachmentList
+
     -- Reset the autocomplete UI
     resetAutocomplete
 
-    -- Empty the attachment list
-    resetAttachmentList
 
     -- Reset the edit mode *after* handling the input so that the input
     -- handler can tell whether we're editing, replying, etc.

--- a/src/Matterhorn/Types.hs
+++ b/src/Matterhorn/Types.hs
@@ -1917,6 +1917,9 @@ data MHError =
     -- ^ The specified script was not found
     | NoSuchHelpTopic T.Text
     -- ^ The specified help topic was not found
+    | BadFile T.Text
+    -- ^ The specified file couldn't be attached.  It either doesn't exist or
+    -- couldn't be read
     | AsyncErrEvent SomeException
     -- ^ For errors that arise in the course of async IO operations
     deriving (Show)

--- a/src/Matterhorn/Types.hs
+++ b/src/Matterhorn/Types.hs
@@ -1917,9 +1917,10 @@ data MHError =
     -- ^ The specified script was not found
     | NoSuchHelpTopic T.Text
     -- ^ The specified help topic was not found
-    | BadAttachmentPath SomeException 
-    -- ^ The specified file couldn't be attached.  It either doesn't exist or
-    -- couldn't be read
+    | AttachmentException SomeException
+    -- ^ IO operations for attaching a file threw an exception
+    | BadAttachmentPath T.Text
+    -- ^ The specified file is either a directory or doesn't exist
     | AsyncErrEvent SomeException
     -- ^ For errors that arise in the course of async IO operations
     deriving (Show)

--- a/src/Matterhorn/Types.hs
+++ b/src/Matterhorn/Types.hs
@@ -1917,7 +1917,7 @@ data MHError =
     -- ^ The specified script was not found
     | NoSuchHelpTopic T.Text
     -- ^ The specified help topic was not found
-    | BadFile T.Text
+    | BadAttachmentPath SomeException T.Text
     -- ^ The specified file couldn't be attached.  It either doesn't exist or
     -- couldn't be read
     | AsyncErrEvent SomeException

--- a/src/Matterhorn/Types.hs
+++ b/src/Matterhorn/Types.hs
@@ -1917,7 +1917,7 @@ data MHError =
     -- ^ The specified script was not found
     | NoSuchHelpTopic T.Text
     -- ^ The specified help topic was not found
-    | BadAttachmentPath SomeException T.Text
+    | BadAttachmentPath SomeException 
     -- ^ The specified file couldn't be attached.  It either doesn't exist or
     -- couldn't be read
     | AsyncErrEvent SomeException


### PR DESCRIPTION
This adds an /attach command, which allows for attaching a file to a message by giving a path directly instead of navigating the file browser.  In order to share code, a few small things moved from the files in the Events directory to ones in the State directory.  As of the first commit, it does not work and is only here to ease discussion.