### PR TITLE
Update user metadata correctly

### DIFF
--- a/src/Matterhorn/Events/Websocket.hs
+++ b/src/Matterhorn/Events/Websocket.hs
@@ -11,7 +11,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import           Lens.Micro.Platform ( (%=), preuse )
+import           Lens.Micro.Platform ( preuse )
 
 import           Network.Mattermost.Lenses
 import           Network.Mattermost.Types
@@ -216,8 +216,7 @@ handleWebsocketEvent we = do
 
         WMUserUpdated
             | Just user <- wepUser (weData we) -> do
-                csUsers %= modifyUserById (userId user)
-                    (\ui -> userInfoFromUser user (ui ^. uiInTeam))
+                handleUserUpdated user
                 cid <- use $ csCurrentChannel . ccInfo . cdChannelId
                 refreshChannelById cid
             | otherwise -> return ()

--- a/src/Matterhorn/State/Users.hs
+++ b/src/Matterhorn/State/Users.hs
@@ -2,6 +2,7 @@
 module Matterhorn.State.Users
   ( handleNewUsers
   , handleTypingUser
+  , handleUserUpdated
   , withFetchedUser
   , withFetchedUserMaybe
   )
@@ -45,6 +46,14 @@ handleTypingUser uId cId = do
         withFetchedUser (UserFetchById uId) $ const $ do
             ts <- liftIO getCurrentTime
             csChannels %= modifyChannelById cId (addChannelTypingUser uId ts)
+
+-- | Handle the websocket event for when a user is updated, e.g. has changed
+-- their nickname
+handleUserUpdated :: User -> MH ()
+handleUserUpdated user = do
+    csUsers %= modifyUserById (userId user)
+        (\ui -> userInfoFromUser user (ui ^. uiInTeam))
+
 
 -- | Given a user fetching strategy, locate the user in the state or
 -- fetch it from the server, and pass the result to the specified

--- a/src/Matterhorn/Types.hs
+++ b/src/Matterhorn/Types.hs
@@ -158,6 +158,7 @@ module Matterhorn.Types
   , csCurrentChannelId
   , csCurrentTeamId
   , csPostMap
+  , csUsers
   , csConnectionStatus
   , csWorkerIsBusy
   , csChannel


### PR DESCRIPTION
This implements a working handler for user metadata.  Previously we were ignoring those websocket events.  Now we correctly update the displayed user information (e.g., nickname) as soon as this happens.  This comes with a related change to `mattermost-api` that changes some of the logging-related types, since those were part of figuring out this fix.

Closes #697 