### PR TITLE
Relax some upper version bounds to allow building with GHC 9.0

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -182,7 +182,7 @@ library
                      , filepath             >= 1.4     && < 1.5
                      , directory            >= 1.3     && < 1.4
                      , vector               < 0.13
-                     , strict               >= 0.3     && < 0.4
+                     , strict               >= 0.3     && < 0.5
                      , hashable             >= 1.2     && < 1.4
                      , commonmark           >= 0.1.1.3 && < 0.2
                      , commonmark-extensions >= 0.2.0.4 && < 0.3
@@ -198,7 +198,7 @@ library
                      , skylighting-core     >= 0.8     && < 0.9
                      , timezone-olson       >= 0.2     && < 0.3
                      , timezone-series      >= 0.1.6.1 && < 0.2
-                     , aeson                >= 1.2.3.0 && < 1.5
+                     , aeson                >= 1.2.3.0 && < 1.6
                      , async                >= 2.2     && < 2.3
                      , uuid                 >= 1.3     && < 1.4
                      , random               >= 1.1     && < 1.2


### PR DESCRIPTION
This relaxes the upper version bounds for `aeson` and `strict` to allow `matterhorn` to build against versions `1.5.*` and `0.4.*`, respectively, which are the minimum versions that build against GHC 9.0.