### PR TITLE
Check cabal-installed data directory for syntax files and emoji.json

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -17,6 +17,9 @@ tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC
 data-files:          syntax/*.xml
                      syntax/language.dtd
                      syntax/LICENSE
+                     emoji/NOTICE.txt
+                     emoji/LICENSE.txt
+                     emoji/emoji.json
 
 extra-doc-files:     CHANGELOG.md
                      README.md

--- a/src/Matterhorn/Config.hs
+++ b/src/Matterhorn/Config.hs
@@ -13,6 +13,8 @@ where
 import           Prelude ()
 import           Matterhorn.Prelude
 
+import qualified Paths_matterhorn as Paths
+
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Class ( lift )
 import           Data.Char ( isDigit, isAlpha )
@@ -48,7 +50,8 @@ defaultSkylightingPaths :: IO [FilePath]
 defaultSkylightingPaths = do
     xdg <- xdgSyntaxDir
     adjacent <- getBundledSyntaxPath
-    return [xdg, adjacent]
+    cabalDataFiles <- Paths.getDataFileName syntaxDirName
+    return [xdg, adjacent, cabalDataFiles]
 
 getBundledSyntaxPath :: IO FilePath
 getBundledSyntaxPath = do

--- a/src/Matterhorn/FilePaths.hs
+++ b/src/Matterhorn/FilePaths.hs
@@ -25,6 +25,8 @@ where
 import Prelude ()
 import Matterhorn.Prelude
 
+import qualified Paths_matterhorn as Paths
+
 import Data.Text ( unpack )
 import System.Directory ( doesFileExist
                         , doesDirectoryExist
@@ -77,6 +79,13 @@ bundledEmojiJsonPath = do
     let distDir = "dist-newstyle/"
         pathBits = splitPath selfPath
 
+    adjacentEmojiJsonPath <- do
+      let path = takeDirectory selfPath </> emojiDirName </> emojiJsonFilename
+      exists <- doesFileExist path
+      return $ if exists then Just path else Nothing
+
+    cabalEmojiJsonPath <- Paths.getDataFileName $ emojiDirName </> emojiJsonFilename
+
     return $ if distDir `elem` pathBits
              then
                  -- We're in development, so use the development
@@ -86,8 +95,10 @@ bundledEmojiJsonPath = do
              else
                  -- In this case we assume the binary is being run from
                  -- a release, in which case the syntax directory is a
-                 -- sibling of the executable path.
-                 takeDirectory selfPath </> emojiDirName </> emojiJsonFilename
+                 -- sibling of the executable path. If it does not exist
+                 -- we fall back to the cabal data files path discovered
+                 -- via Paths.getDataFileName.
+                 fromMaybe cabalEmojiJsonPath adjacentEmojiJsonPath
 
 emojiJsonFilename :: FilePath
 emojiJsonFilename = "emoji.json"


### PR DESCRIPTION
When installed using cabal, we can use the `Paths_matterhorn` module and `getDataFileName` to get the paths to files and directories which are listed in `data-files` in `matterhorn.cabal`.

This fixes wrong assumptions of matterhorn when it is installed in a different way than the official release build. For example in NixOS we install data files to a separate location cabal knows about, so this change is necessary to make for example emoji completion work on NixOS: https://github.com/NixOS/nixpkgs/issues/129048.

I'd suggest you switch to `getDataFileName` completely, but since I don't know anything about the release build process, I can't implement such a change. 