### PR TITLE
Render attachment text fields

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -191,6 +191,7 @@ library
                      , word-wrap            >= 0.4.0   && < 0.5
                      , transformers         >= 0.4     && < 0.6
                      , text-zipper          >= 0.11    && < 0.12
+                     , text-conversions     >= 0.3
                      , time                 >= 1.6     && < 2.0
                      , xdg-basedir          >= 0.2     && < 0.3
                      , filepath             >= 1.4     && < 1.5

--- a/src/Matterhorn/Types/Posts.hs
+++ b/src/Matterhorn/Types/Posts.hs
@@ -48,12 +48,15 @@ where
 import           Prelude ()
 import           Matterhorn.Prelude
 
+import qualified Brick as B
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import qualified Data.Set as S
 import           Data.Time.Clock ( getCurrentTime )
 import           Lens.Micro.Platform ( makeLenses )
+import           Data.Text.Conversions
+import           Text.Printf
 
 import           Network.Mattermost.Lenses
 import           Network.Mattermost.Types
@@ -223,7 +226,13 @@ getAttachmentText p =
     Just attachments ->
       Blocks $ fmap (Blockquote . render) attachments
   where render att = parseMarkdown Nothing (att^.ppaTextL) <>
-                     parseMarkdown Nothing (att^.ppaFallbackL)
+                     parseMarkdown Nothing (att^.ppaFallbackL) <>
+                     parseMarkdown Nothing (toText $ unlines $ toList $ fmap renderAttField (att^.ppaFieldsL))
+
+renderAttField :: PostPropAttachmentField -> String
+renderAttField f = "  * " ++
+  (if (ppafTitle f) == T.empty then "" else printf "**%s:** " (ppafTitle f)) ++
+  printf "%s" (ppafValue f)
 
 -- ** 'ClientPost' Lenses
 


### PR DESCRIPTION
Please pardon my total lack of experience with Haskell, first of all. :stuck_out_tongue:

Mattermost supports attaching simple key/value fields to messages, but Matterhorn currently does not support displaying them. This patch adds a bulleted list at the end of messages displaying any attached key/value fields that they may have.