### PR TITLE
Support building with GHC 9.6

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -184,18 +184,18 @@ library
                      , config-ini           >= 0.2.2.0 && < 0.3
                      , process              >= 1.4     && < 1.7
                      , microlens-platform   >= 0.3     && < 0.5
-                     , brick                >= 1.6     && < 1.7
+                     , brick                >= 1.6     && < 1.8
                      , brick-skylighting    >= 1.0     && < 1.1
                      , vty                  >= 5.38    && < 5.39
                      , word-wrap            >= 0.4.0   && < 0.5
                      , transformers         >= 0.4     && < 0.6
-                     , text-zipper          >= 0.12    && < 0.13
+                     , text-zipper          >= 0.12    && < 0.14
                      , time                 >= 1.6     && < 2.0
                      , xdg-basedir          >= 0.2     && < 0.3
                      , filepath             >= 1.4     && < 1.5
                      , directory            >= 1.3     && < 1.4
                      , vector               < 0.13
-                     , strict               >= 0.3     && < 0.5
+                     , strict               >= 0.3     && < 0.6
                      , hashable             >= 1.2     && < 1.5
                      , commonmark           >= 0.2.1   && < 0.3
                      , commonmark-extensions >= 0.2.1.2 && < 0.3
@@ -207,7 +207,7 @@ library
                      , mtl                  >= 2.2     && < 2.3
                      , aspell-pipe          >= 0.6     && < 0.7
                      , stm-delay            >= 0.1     && < 0.2
-                     , unix                 >= 2.7.1.0 && < 2.7.3.0
+                     , unix                 >= 2.7.1.0 && < 2.9
                      , skylighting-core     >= 0.12    && < 0.13
                      , timezone-olson       >= 0.2     && < 0.3
                      , timezone-series      >= 0.1.6.1 && < 0.2
@@ -249,7 +249,7 @@ test-suite test_messages
   build-depends:      base                 >=4.7      && <5
                     , Unique               >= 0.4     && < 0.5
                     , checkers             >= 0.4     && < 0.6
-                    , tasty                >= 0.11    && < 1.3
+                    , tasty                >= 0.11    && < 1.5
                     , tasty-hunit          >= 0.9     && < 0.12
                     , tasty-quickcheck     >= 0.8     && < 0.12
                     , bytestring

--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -188,7 +188,7 @@ library
                      , brick-skylighting    >= 1.0     && < 1.1
                      , vty                  >= 5.38    && < 5.39
                      , word-wrap            >= 0.4.0   && < 0.5
-                     , transformers         >= 0.4     && < 0.6
+                     , transformers         >= 0.4     && < 0.7
                      , text-zipper          >= 0.12    && < 0.14
                      , time                 >= 1.6     && < 2.0
                      , xdg-basedir          >= 0.2     && < 0.3
@@ -204,7 +204,7 @@ library
                      , temporary            >= 1.2     && < 1.4
                      , gitrev               >= 1.3     && < 1.4
                      , Hclip                >= 3.0     && < 3.1
-                     , mtl                  >= 2.2     && < 2.3
+                     , mtl                  >= 2.2     && < 2.4
                      , aspell-pipe          >= 0.6     && < 0.7
                      , stm-delay            >= 0.1     && < 0.2
                      , unix                 >= 2.7.1.0 && < 2.9

--- a/src/Matterhorn/Emoji.hs
+++ b/src/Matterhorn/Emoji.hs
@@ -12,7 +12,8 @@ import           Prelude ()
 import           Matterhorn.Prelude
 
 import qualified Control.Exception as E
-import           Control.Monad.Except
+import           Control.Monad.Except ( MonadError(..), ExceptT(..), runExceptT )
+import           Control.Monad.Trans ( MonadTrans(..) )
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Foldable as F


### PR DESCRIPTION
For the most part, this simply requires bumping upper version bounds. I did need to make a minor code change to support `mtl-2.3.*`, which no longer re-exports as many things (e.g., `MonadTrans(lift)`) as previous versions do.