### PR TITLE
Allow building with `vty-windows-0.2.0.2`

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -186,8 +186,8 @@ library
                      , microlens-platform   >= 0.3     && < 0.5
                      , brick                >= 2.0     && < 2.1
                      , brick-skylighting    >= 1.0     && < 1.1
-                     , vty                  >= 6.0     && < 6.1
-                     , vty-crossplatform    >= 0.2.0.0 && < 0.3.0.0
+                     , vty                  >= 6.0     && < 6.3
+                     , vty-crossplatform    >= 0.2.0.0 && < 0.5.0.0
                      , word-wrap            >= 0.4.0   && < 0.5
                      , transformers         >= 0.4     && < 0.7
                      , text-zipper          >= 0.13    && < 0.14


### PR DESCRIPTION
`vty-windows-0.2.0.2` contains an important bugfix for recent versions of Microsoft Terminal (see https://github.com/chhackett/vty-windows/pull/17), without which it is impossible to type any input into `vty`. In order to permit a build plan that includes `vty-windows-0.2.0.2`, I needed to raise the upper version bounds on `vty` and `vty-crossplatform`.