### PR TITLE
Autocomplete user lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,31 @@
 
+90000.0.0
+=========
+
+NOTE: this version of Matterhorn requires server version 9.0 or greater.
+
+Package changes:
+* Updated to use Vty 6 for crossplatform terminal support, meaning
+  Matterhorn can now be built and run on Windows terminals. Please let
+  us know if you try this and encounter any issues!
+
+Enhancements:
+* Added support for a new "auto" mode to determine channel list width.
+  There is now a new `auto` value for the `channelListWidth`
+  configuration file setting. Its default is unchanged and it can still
+  take an integer value specifying the channel list width in columns.
+  If set to `auto`, its value is determined by Matterhorn, bounded by
+  minimum and maximum values, as a function of window width. This is
+  intended to give nicer results as font size decreases, up to a point.
+* Add a `/write-theme` command to write the current theme to an INI
+  file.
+
+Bug fixes:
+* Updated channel viewing book-keeping to work with changes in
+  Mattermost 9.0.
+* Fixed an issue where terminal input provided right before the UI is
+  initialized could cause the application to crash.
+
 50200.19.0
 ==========
 

--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -1,5 +1,5 @@
 name:                matterhorn
-version:             50200.19.0
+version:             90000.0.0
 synopsis:            Terminal client for the Mattermost chat system
 description:         This is a terminal client for the Mattermost chat
                      system. Please see the README for a list of
@@ -170,7 +170,7 @@ library
     ghc-options: -fhide-source-paths
 
   build-depends:       base                 >=4.8      && <5
-                     , mattermost-api       == 50200.15.0
+                     , mattermost-api       == 90000.0.0
                      , base-compat          >= 0.9     && < 0.13
                      , unordered-containers >= 0.2     && < 0.3
                      , containers           >= 0.5.7   && < 0.7

--- a/src/Matterhorn/Draw/Autocomplete.hs
+++ b/src/Matterhorn/Draw/Autocomplete.hs
@@ -133,7 +133,7 @@ renderAutocompleteBox st tId mCurChan which ac =
 renderAutocompleteFooterFor :: ChatState -> ClientChannel -> AutocompleteAlternative -> Maybe (Widget Name)
 renderAutocompleteFooterFor _ _ (SpecialMention MentionChannel) = Nothing
 renderAutocompleteFooterFor _ _ (SpecialMention MentionAll) = Nothing
-renderAutocompleteFooterFor st ch (UserCompletion _ False) =
+renderAutocompleteFooterFor st ch (UserCompletion _ False _) =
     Just $ hBox [ txt $ "("
                 , withDefAttr clientEmphAttr (txt userNotInChannelMarker)
                 , txt ": not a member of "
@@ -166,7 +166,7 @@ renderAutocompleteAlternative _ sel (EmojiCompletion e) =
     padRight Max $ renderEmojiCompletion sel e
 renderAutocompleteAlternative _ sel (SpecialMention m) =
     padRight Max $ renderSpecialMention m sel
-renderAutocompleteAlternative curUser sel (UserCompletion u inChan) =
+renderAutocompleteAlternative curUser sel (UserCompletion u inChan _) =
     padRight Max $ renderUserCompletion curUser u inChan sel
 renderAutocompleteAlternative _ sel (ChannelCompletion inChan c) =
     padRight Max $ renderChannelCompletion c inChan sel

--- a/src/Matterhorn/Events.hs
+++ b/src/Matterhorn/Events.hs
@@ -87,6 +87,9 @@ onAppEvent WebsocketConnect = do
     refreshChannelsAndUsers
     refreshClientConfig
     withCurrentTeam fetchVisibleIfNeeded
+    forEachTeam $ \tId -> do
+        baseUrl <- getServerBaseUrl tId
+        mhLog LogGeneral $ T.pack $ "Team base URL for team ID " <> show tId <> ": " <> show baseUrl
 onAppEvent (RateLimitExceeded winSz) =
     mhError $ GenericError $ T.pack $
         let s = if winSz == 1 then "" else "s"

--- a/src/Matterhorn/Types.hs
+++ b/src/Matterhorn/Types.hs
@@ -178,6 +178,7 @@ module Matterhorn.Types
   , withCurrentChannel
   , withCurrentChannel'
   , withCurrentTeam
+  , forEachTeam
 
   , csTeamZipper
   , csTeams
@@ -1808,6 +1809,11 @@ withCurrentTeam f = do
     case mtId of
         Nothing -> return ()
         Just tId -> f tId
+
+forEachTeam :: (TeamId -> MH ()) -> MH ()
+forEachTeam f = do
+    ts <- use csTeams
+    mapM_ f (HM.keys ts)
 
 withCurrentChannel :: TeamId -> (ChannelId -> ClientChannel -> MH ()) -> MH ()
 withCurrentChannel tId f = do


### PR DESCRIPTION
Auto-completion works for commands where one or more users can be specified and each user is a separate word (e.g. `/msg @userA ...` or `/group-create @userA @userB ...`), but it does not work for commands which take a comma-separated list of users (e.g. `/groupmsg @userA,@userB ...`).  This is primarily because the existing auto-completion implementation expects to auto-complete the entire current word.

The observable behavior is that the user auto-completion list is presented for the first user entered to the `/groupmsg` command, but after the comma and subsequent '@' (user sigil), no auto-completion assistance is provided for the usernames.

This PR updates the User auto-completion to search for (the last) `,@` character sequence and only use the final portion following that last sigil as the search text for the user auto-completion.  It extends the `UserCompletion` data structure to remember any previous portion of the line (up to and including the last `,@`) and provide that on replacement so that the replacement provides the entire list and not just the last auto-completed user.

This should be fully backward compatible with existing functionality.  There is a small downside in that it will "allow" auto-completion of a user list for *any* command (there is no filter for only auto-completing user lists for commands that accept user lists). Thus, one could type `/msg @userA,@` and auto-completion assistance would be provided for selecting another user.  At the present time, the LOE needed to mitigate this "downside" is probably not justified: the user can type a user-list without the auto-completion assistance anyhow, and the server will reject such a message (with normal Matterhorn display of that server rejection).