### PR TITLE
Allow auto-completion of all users in a comma-separated list.

### DIFF
--- a/src/Matterhorn/Draw/Autocomplete.hs
+++ b/src/Matterhorn/Draw/Autocomplete.hs
@@ -133,7 +133,7 @@ renderAutocompleteBox st tId mCurChan which ac =
 renderAutocompleteFooterFor :: ChatState -> ClientChannel -> AutocompleteAlternative -> Maybe (Widget Name)
 renderAutocompleteFooterFor _ _ (SpecialMention MentionChannel) = Nothing
 renderAutocompleteFooterFor _ _ (SpecialMention MentionAll) = Nothing
-renderAutocompleteFooterFor st ch (UserCompletion _ False) =
+renderAutocompleteFooterFor st ch (UserCompletion _ False _) =
     Just $ hBox [ txt $ "("
                 , withDefAttr clientEmphAttr (txt userNotInChannelMarker)
                 , txt ": not a member of "
@@ -166,7 +166,7 @@ renderAutocompleteAlternative _ sel (EmojiCompletion e) =
     padRight Max $ renderEmojiCompletion sel e
 renderAutocompleteAlternative _ sel (SpecialMention m) =
     padRight Max $ renderSpecialMention m sel
-renderAutocompleteAlternative curUser sel (UserCompletion u inChan) =
+renderAutocompleteAlternative curUser sel (UserCompletion u inChan _) =
     padRight Max $ renderUserCompletion curUser u inChan sel
 renderAutocompleteAlternative _ sel (ChannelCompletion inChan c) =
     padRight Max $ renderChannelCompletion c inChan sel


### PR DESCRIPTION
Auto-completion works for commands where one or more users can be specified and each user is a separate word (e.g. /msg @userA ... or /group-create @userA @userB ...), but it does not work for commands which take a comma-separated list of users (e.g. /groupmsg @userA,@userB ...). This is primarily because the existing auto-completion implementation expects to auto-complete the entire current word.

The observable behavior is that the user auto-completion list is presented for the first user entered to the /groupmsg command, but after the comma and subsequent '@' (user sigil), no auto-completion assistance is provided for the usernames.

This PR updates the User auto-completion to search for (the last) ,@ character sequence and only use the final portion following that last sigil as the search text for the user auto-completion. It extends the UserCompletion data structure to remember any previous portion of the line (up to and including the last ,@) and provide that on replacement so that the replacement provides the entire list and not just the last auto-completed user.

This should be fully backward compatible with existing functionality. There is a small downside in that it will "allow" auto-completion of a user list for any command (there is no filter for only auto-completing user lists for commands that accept user lists). Thus, one could type /msg @userA,@ and auto-completion assistance would be provided for selecting another user. At the present time, the LOE needed to mitigate this "downside" is probably not justified: the user can type a user-list without the auto-completion assistance anyhow, and the server will reject such a message (with normal Matterhorn display of that server rejection).