### PR TITLE
Added notification version 4 with channel name and type

### DIFF
--- a/docs/notification-scripts.md
+++ b/docs/notification-scripts.md
@@ -42,7 +42,7 @@ The interface for notification scripts is as follows:
   passing notification details via JSON to the command's standard input.
   The JSON will be UTF-8 encoded; the notification script is responsible
   for decoding it.
-  * NotifyV2 JSON payload fields:
+  * NotifyV3 JSON payload fields:
     * "version": "3"
     * "from": "sender name"
     * "message": "message text..."

--- a/docs/notification-scripts.md
+++ b/docs/notification-scripts.md
@@ -60,6 +60,36 @@ The interface for notification scripts is as follows:
       * `ephemeral`
       * `unknown`
 
+* NotifyV4: Matterhorn will invoke the command with zero arguments,
+  passing notification details via JSON to the command's standard input.
+  The JSON will be UTF-8 encoded; the notification script is responsible
+  for decoding it.
+  * NotifyV4 JSON payload fields:
+    * "version": "4"
+    * "from": "sender name"
+    * "message": "message text..."
+    * "mention": boolean (true or false: did sender mention me?)
+    * "messageType": a string from the following list based on the
+      message type:
+      * `joinChannel`
+      * `leaveChannel`
+      * `addToChannel`
+      * `removeFromChannel`
+      * `headerChange`
+      * `displayNameChange`
+      * `purposeChange`
+      * `channelDeleted`
+      * `ephemeral`
+      * `unknown`
+    * "channel": the channel slug
+    * "channelType": a string from the following list based on the
+      type of channel where the notification originated:
+      * `D` for direct messages
+      * `O` for ordinary channels
+      * `P` for private channels
+      * `G` for group DMs
+      * `U` for unknown types
+
 * Matterhorn will wait for the process to terminate. If the process
   emits any output to standard out OR if the command exits with a
   non-zero exit status, Matterhorn will consider that evidence that

--- a/src/Matterhorn/Config.hs
+++ b/src/Matterhorn/Config.hs
@@ -339,8 +339,9 @@ notifyVersion t =
         "1" -> Right NotifyV1
         "2" -> Right NotifyV2
         "3" -> Right NotifyV3
+        "4" -> Right NotifyV4
         _ -> Left ("Invalid value " <> show t
-                  <> "; must be one of NotifyV1, NotifyV2, NotifyV3")
+                  <> "; must be one of NotifyV1, NotifyV2, NotifyV3, NotifyV4")
 
 parseChannelListSorting :: Text -> Either String ChannelListSorting
 parseChannelListSorting t =

--- a/src/Matterhorn/Config.hs
+++ b/src/Matterhorn/Config.hs
@@ -338,8 +338,9 @@ notifyVersion t =
     case t of
         "1" -> Right NotifyV1
         "2" -> Right NotifyV2
+        "3" -> Right NotifyV3
         _ -> Left ("Invalid value " <> show t
-                  <> "; must be one of NotifyV1, NotifyV2")
+                  <> "; must be one of NotifyV1, NotifyV2, NotifyV3")
 
 parseChannelListSorting :: Text -> Either String ChannelListSorting
 parseChannelListSorting t =

--- a/src/Matterhorn/State/Messages.hs
+++ b/src/Matterhorn/State/Messages.hs
@@ -865,8 +865,8 @@ notifyGetPayload NotifyV3 st post mentioned = do
 notifyGetPayload NotifyV4 st post mentioned = do
     chan <- findChannelById (post^.postChannelIdL) (st^.csChannels)
     let chName = chan^.ccInfo.cdName
-    let chType = notifyGetChannelType chan
-    let notification = NotificationV4 4 msg mentioned sender msgTy chName chType
+        chType = notifyGetChannelType chan
+        notification = NotificationV4 4 msg mentioned sender msgTy chName chType
     return (A.encode notification)
         where
             msg = sanitizeUserText $ postMessage post

--- a/src/Matterhorn/Types.hs
+++ b/src/Matterhorn/Types.hs
@@ -449,6 +449,7 @@ data NotificationVersion =
     NotifyV1
     | NotifyV2
     | NotifyV3
+    | NotifyV4
     deriving (Eq, Read, Show)
 
 -- | A user password is either given to us directly, or a command


### PR DESCRIPTION
Decided to give it a go on including the channel name and type on the notification payload, so here is notification version 4.

(fixes #805)