### PR TITLE
Fix the -i/--ignore-configuration option.

### DIFF
--- a/programs/Main.hs
+++ b/programs/Main.hs
@@ -19,9 +19,7 @@ main :: IO ()
 main = do
     opts <- grabOptions
 
-    configResult <- findConfig $ if optIgnoreConfig opts
-                                 then Nothing
-                                 else optConfLocation opts
+    configResult <- tryLoadConfig (optIgnoreConfig opts) (optConfLocation opts)
 
     config <- case configResult of
         Left err -> do

--- a/scripts/local-mkrelease.sh
+++ b/scripts/local-mkrelease.sh
@@ -163,7 +163,7 @@ echo
 echo %
 echo % Verify that the command document is current
 echo %
-diff docs/commands.md <(./run.sh -m -f markdown)
+diff docs/commands.md <(./run.sh -i -m -f markdown)
 echo
 
 TMPDIR=$(mktemp -d)


### PR DESCRIPTION
Make the code that loads the configuration explicitly return the default configuration without any config file lookups if the option to ignore the configuration is used. The current implementation tries to make the function that looks up the configuration file not load anything by passing a null value to it, but that behavior clashes with the behavior of the `-c`/`--config` option, which when not used results in the same value being passed to the function, so it doesn't have a way of differentiating between the two. As a result, if you have a configuration file in any of the default locations it'll load it regardless.

(Fixes (#847)