### PR TITLE
Relax version bounds for GHC 9.10.3 compatibility

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -186,7 +186,7 @@ library
                      , microlens-platform   >= 0.3     && < 0.5
                      , brick                >= 2.8.3   && < 2.9
                      , brick-skylighting    >= 1.0     && < 1.1
-                     , vty                  >= 6.4     && < 6.5
+                     , vty                  >= 6.4     && < 6.6
                      , vty-crossplatform    >= 0.2.0.0 && < 0.6.0.0
                      , word-wrap            >= 0.4.0   && < 0.5
                      , transformers         >= 0.4     && < 0.7
@@ -215,7 +215,7 @@ library
                      , aeson                >= 1.2.3.0 && < 2.3
                      , async                >= 2.2     && < 2.3
                      , uuid                 >= 1.3     && < 1.4
-                     , random               >= 1.1     && < 1.2
+                     , random               >= 1.1     && < 1.4
                      , network-uri          >= 2.6     && < 2.7
                      , bimap                >= 0.5     && < 0.6
   default-language:    Haskell2010


### PR DESCRIPTION
## Summary

This PR relaxes upper bounds on `vty` and `random` dependencies to allow building matterhorn with GHC 9.10.3.

## Changes

- **vty**: Relax upper bound from `<6.5` to `<6.6` to allow vty-6.5
- **random**: Relax upper bound from `<1.2` to `<1.4` to resolve dependency conflict with uuid (which requires random >=1.2.1.2)

## Testing

Tested with GHC 9.10.3 on OpenBSD:
- ✅ `cabal build all`: successful compilation with all dependencies resolved
- ✅ `cabal test matterhorn:test_messages`: all 77 tests passed

## Motivation

These changes are needed for packaging matterhorn for OpenBSD ports with the latest GHC 9.10.3 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)