### PR TITLE
Backport GHC 9.10.3 compatibility to 90000.0.0

### DIFF
--- a/matterhorn.cabal
+++ b/matterhorn.cabal
@@ -186,8 +186,8 @@ library
                      , microlens-platform   >= 0.3     && < 0.5
                      , brick                >= 2.8.3   && < 2.9
                      , brick-skylighting    >= 1.0     && < 1.1
-                     , vty                  >= 6.4     && < 6.5
-                     , vty-crossplatform    >= 0.2.0.0 && < 0.5.0.0
+                     , vty                  >= 6.4     && < 6.6
+                     , vty-crossplatform    >= 0.2.0.0 && < 0.6.0.0
                      , word-wrap            >= 0.4.0   && < 0.5
                      , transformers         >= 0.4     && < 0.7
                      , text-zipper          >= 0.13    && < 0.14
@@ -216,7 +216,7 @@ library
                      , aeson                >= 2.2     && < 2.3
                      , async                >= 2.2     && < 2.3
                      , uuid                 >= 1.3     && < 1.4
-                     , random               >= 1.1     && < 1.2
+                     , random               >= 1.1     && < 1.4
                      , network-uri          >= 2.6     && < 2.7
                      , bimap                >= 0.5     && < 0.6
   default-language:    Haskell2010


### PR DESCRIPTION
Relaxes version bounds for GHC 9.10.3 compatibility:
- vty
- vty-crossplatform
- random

Tested with GHC 9.10.3 on OpenBSD:
- cabal build all: successful
- all dependencies resolved with newer library versions